### PR TITLE
Remove `results` array

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,24 @@ Then put it to work immediately wherever you want cancellable promises. (Cancell
 
 All tasks will return a store with the same structure:
 
-- `error`: Error - if an error occurred, it will be returned here,
 - `isRunning`: Boolean - whether the task is currently running or not
-- `lastSuccessful`: Any - the return value from the last successful run of the task
+- `last`: TaskInstance | undefined - the last task instance, regardless of whether it errored, was canceled, or was successful
+- `lastCanceled`: TaskInstance | undefined - the last canceled task instance
+- `lastErrored`: TaskInstance | undefined - the last errored task instance
+- `lastRunning`: TaskInstance | undefined - the last running task instance, as soon as the task stops running, this will be undefined
+- `lastSuccessful`: TaskInstance | undefined - the last successful task instance
 - `performCount`: Number - the number of times the task has been run,
 
+## Task Instance
+
+All TaskInstances will have the same structure:
+
+- `error`: undefined | unknown - if an error is thrown inside the task instance, it will be found here
+- `isCanceled`: boolean - whether the task instance was canceled
+- `isError`: boolean - whether the task instance throw an error before completing
+- `isRunning`: boolean - whether the task instance is currently running
+- `isSuccessful`: boolean - whether the task instance completed successfully
+- `value`: undefined | TReturn - if the task instance completed successfully, this will be the return value
 
 ## Task types
 
@@ -217,7 +230,7 @@ Both of the above will result in 3 simultaneous tasks being allowed to run initi
 
 ### Accessing the task in the template
 
-As the return value from the task wrapper is a store, you can access it just like you would with any other store:
+As the return value from the task wrapper is a store, you can access it just like you would with any other store (check the [Task Instance](#task-instance) section for more detail about what to expect):
 
 ```svelte
 <script>
@@ -229,9 +242,8 @@ As the return value from the task wrapper is a store, you can access it just lik
 	});
 </script>
 
-{$myTask.error}
 {$myTask.isRunning}
-{$myTask.lastSuccessful}
+{$myTask.last.value}
 {$myTask.performCount}
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All tasks will return a store with the same structure:
 - `isRunning`: Boolean - whether the task is currently running or not
 - `lastSuccessful`: Any - the return value from the last successful run of the task
 - `performCount`: Number - the number of times the task has been run,
-- `results`: Array - all of the results from previous invocations of this task,
+
 
 ## Task types
 
@@ -233,7 +233,6 @@ As the return value from the task wrapper is a store, you can access it just lik
 {$myTask.isRunning}
 {$myTask.lastSuccessful}
 {$myTask.performCount}
-{$myTask.results}
 ```
 
 ## Task Cancellation

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 // Reexport your entry components here
 import { task, CancelationError } from './task.js';
-export type { Task, SheepdogUtils, TaskDerivedState } from './task.js';
+export type { Task, SheepdogUtils, TaskInstance } from './task.js';
 
 export { task, CancelationError };

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -17,7 +17,7 @@ export type TaskInstance<TReturn = undefined> = {
 	value?: undefined | TReturn;
 };
 
-export function _task<TArgs = unknown, TReturn = undefined>(
+function _task<TArgs = unknown, TReturn = undefined>(
 	gen_or_fun: (
 		args: TArgs,
 		utils: SheepdogUtils,

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -8,7 +8,7 @@ export { CancelationError };
 
 export type Task<TArgs = unknown, TReturn = unknown> = ReturnType<typeof task<TArgs, TReturn>>;
 
-export type TaskDerivedState<TReturn = undefined> = {
+export type TaskInstance<TReturn = undefined> = {
 	error?: undefined | unknown;
 	isCanceled: boolean;
 	isError: boolean;
@@ -26,17 +26,16 @@ export function _task<TArgs = unknown, TReturn = undefined>(
 ) {
 	const { subscribe, ...result } = writable({
 		isRunning: false,
-		last: undefined as undefined | TaskDerivedState<TReturn>,
-		lastCanceled: undefined as undefined | TaskDerivedState<TReturn>,
-		lastErrored: undefined as undefined | TaskDerivedState<TReturn>,
-		lastRunning: undefined as undefined | TaskDerivedState<TReturn>,
-		lastSuccessful: undefined as undefined | TaskDerivedState<TReturn>,
-		results,
+		last: undefined as undefined | TaskInstance<TReturn>,
+		lastCanceled: undefined as undefined | TaskInstance<TReturn>,
+		lastErrored: undefined as undefined | TaskInstance<TReturn>,
+		lastRunning: undefined as undefined | TaskInstance<TReturn>,
+		lastSuccessful: undefined as undefined | TaskInstance<TReturn>,
 		performCount: 0,
 	});
 
 	const updateResult = (
-		instance: TaskDerivedState<TReturn> | undefined,
+		instance: TaskInstance<TReturn> | undefined,
 		new_instance: boolean = false,
 	) => {
 		return result.update((old) => {
@@ -67,7 +66,7 @@ export function _task<TArgs = unknown, TReturn = undefined>(
 		});
 	};
 
-	const instances = new Map<string, TaskDerivedState<TReturn>>();
+	const instances = new Map<string, TaskInstance<TReturn>>();
 
 	const actual_task = createTask<TArgs, TReturn>(
 		{

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -24,8 +24,6 @@ export function _task<TArgs = unknown, TReturn = undefined>(
 	) => Promise<TReturn> | AsyncGenerator<unknown, TReturn, unknown>,
 	options?: TaskOptions,
 ) {
-	const results: TReturn[] = [];
-
 	const { subscribe, ...result } = writable({
 		isRunning: false,
 		last: undefined as undefined | TaskDerivedState<TReturn>,
@@ -104,7 +102,6 @@ export function _task<TArgs = unknown, TReturn = undefined>(
 				updateResult(instance, true);
 			},
 			onInstanceComplete(instance_id, last_result) {
-				results.push(last_result);
 				const instance = instances.get(instance_id);
 				if (instance) {
 					instance.isRunning = false;


### PR DESCRIPTION
This PR was initially just meant to remove the `results` array from the task store, but then I realised that `TaskDerivedState` should probably be called `TaskInstance` and that led me to also update the README

Closes #102 