### PR TITLE
Quality-of-life additions

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,9 @@
 	},
 	"peerDependencies": {
 		"svelte": "^4.0.0"
+	},
+	"volta": {
+		"node": "20.15.1",
+		"pnpm": "9.5.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "vite dev",
+		"docs:dev": "pnpm --filter 'docs' dev",
+		"docs:install": "pnpm --filter 'docs' install",
 		"format": "eslint . --fix && prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"package": "svelte-kit sync && svelte-package && publint",


### PR DESCRIPTION
This PR adds two things to make development easier:
- it pins node and pnpm to the latest versions,
- it adds `docs:dev` and `docs:install` commands to the root repo so that we don't need to change folders to run the docs site