### PR TITLE
feat: return derived state to `perform` return value

### DIFF
--- a/src/lib/internal/helpers.ts
+++ b/src/lib/internal/helpers.ts
@@ -1,0 +1,36 @@
+import { writable } from 'svelte/store';
+import type { Readable, Writable } from 'svelte/store';
+/**
+ * Thanks to Melt-UI for the implementation
+ * https://github.com/melt-ui/melt-ui/blob/284582b759ec9ad31166bd75f09b4bfa3b35b650/src/lib/internal/helpers/withGet.ts
+ */
+
+type ReadableValue<T> = T extends Readable<infer V> ? V : never;
+
+type WithGet<T extends Readable<unknown>> = T & {
+	get: () => ReadableValue<T>;
+};
+
+export type WritableWithGet<T> = WithGet<Writable<T>>;
+export type ReadableWithGet<T> = WithGet<Readable<T>>;
+
+export function writable_with_get<T>(initial: T): WritableWithGet<T> {
+	const internal = writable(initial);
+	let value = initial;
+
+	return {
+		subscribe: internal.subscribe,
+		set(new_value) {
+			internal.set(new_value);
+			value = new_value;
+		},
+		update(updater) {
+			const new_value = updater(value);
+			internal.set(new_value);
+			value = new_value;
+		},
+		get() {
+			return value;
+		},
+	};
+}

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -78,6 +78,9 @@ function _task<TArgs = unknown, TReturn = undefined>(
 						instance.isError = true;
 						return instance;
 					});
+					// we delete after a microtask to avoid returnModifier
+					// not founding the instance in case of a syncronous
+					// cancellation (for example with drop)
 					queueMicrotask(() => {
 						instances.delete(instance_id);
 					});
@@ -92,6 +95,9 @@ function _task<TArgs = unknown, TReturn = undefined>(
 						instance.isCanceled = true;
 						return instance;
 					});
+					// we delete after a microtask to avoid returnModifier
+					// not founding the instance in case of a syncronous
+					// cancellation (for example with drop)
 					queueMicrotask(() => {
 						instances.delete(instance_id);
 					});
@@ -128,6 +134,9 @@ function _task<TArgs = unknown, TReturn = undefined>(
 						instance.value = last_result;
 						return instance;
 					});
+					// we delete after a microtask to avoid returnModifier
+					// not founding the instance in case of a synchronous
+					// cancellation (for example with drop)
 					queueMicrotask(() => {
 						instances.delete(instance_id);
 					});

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -78,6 +78,9 @@ function _task<TArgs = unknown, TReturn = undefined>(
 						instance.isError = true;
 						return instance;
 					});
+					queueMicrotask(() => {
+						instances.delete(instance_id);
+					});
 					updateResult(instance.get());
 				}
 			},
@@ -88,6 +91,9 @@ function _task<TArgs = unknown, TReturn = undefined>(
 						instance.isRunning = false;
 						instance.isCanceled = true;
 						return instance;
+					});
+					queueMicrotask(() => {
+						instances.delete(instance_id);
 					});
 					updateResult(instance.get());
 				}
@@ -121,6 +127,9 @@ function _task<TArgs = unknown, TReturn = undefined>(
 						instance.isSuccessful = true;
 						instance.value = last_result;
 						return instance;
+					});
+					queueMicrotask(() => {
+						instances.delete(instance_id);
 					});
 					updateResult(instance.get());
 				}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => ({
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
 		setupFiles: './src/vitest-setup.ts',
+		retry: 1,
 		coverage: {
 			exclude: [
 				'src/routes/**/*',


### PR DESCRIPTION
Closes #131 

This modify the adapter to add both a `onInstanceCreate` and `returnModifier` that allow every user of `core` (basically us when we will build more versions of the library) to modify the return value of `perform`.

In this case we are also attaching a subscribe function so that the whole thing is a store that contains the derived state. When we will switch to runes we will probably create a state out it before returning it.

I've also added a `retry: 1` to the vite config because we saw some flaky tests (probably related to some milliseconds changes)

@nickschot since me and @beerinho paired on this it would be good to have your review on this.