### PR TITLE
Extend the TaskInstance derived state

### DIFF
--- a/src/lib/tests/components/enqueue.svelte
+++ b/src/lib/tests/components/enqueue.svelte
@@ -13,6 +13,9 @@
 	export const default_task = task.enqueue(fn, { max });
 	export const options_task = task(fn, { kind: 'enqueue', max });
 
+	export const get_latest_default_task_instance = () => latest_task_instance;
+	export const get_latest_options_task_instance = () => latest_options_task_instance;
+
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
 	let latest_options_task_instance: ReturnType<typeof options_task.perform>;
 </script>


### PR DESCRIPTION
~Blocked by #132~

The PR adds two new properties to the TaskInstance:
- `hasStarted` - starts as `false` and then as soon as the instance is started it changes to `true`,
- `isFinished` - starts as `false` and regardless of how it finishes (errored, cancelled or successfully) will switch to `true`

Closes #125
Closes #127 