### PR TITLE
fix: make async transform with dot notation too

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"prepublishOnly": "npm run package",
 		"preview": "vite preview",
 		"generate-expected": "tsm ./src/lib/tests/expected-transforms/generate-expected.ts",
+		"generate-expected-force": "tsm ./src/lib/tests/expected-transforms/generate-expected.ts -f",
 		"test": "npm run test:unit",
 		"test:integration": "playwright test",
 		"test:unit": "vitest",

--- a/src/lib/tests/expected-transforms/dot-notation/code.js
+++ b/src/lib/tests/expected-transforms/dot-notation/code.js
@@ -1,0 +1,21 @@
+import { task } from "@sheepdog/svelte";
+
+task.drop(async () => {
+	await Promise.resolve();
+});
+
+task.enqueue(async () => {
+	await Promise.resolve();
+});
+
+task.default(async () => {
+	await Promise.resolve();
+});
+
+task.keepLatest(async () => {
+	await Promise.resolve();
+});
+
+task.restart(async () => {
+	await Promise.resolve();
+});

--- a/src/lib/tests/expected-transforms/dot-notation/transform.js
+++ b/src/lib/tests/expected-transforms/dot-notation/transform.js
@@ -1,0 +1,21 @@
+import { task } from "@sheepdog/svelte";
+
+task.drop(async function* () {
+	yield Promise.resolve();
+});
+
+task.enqueue(async function* () {
+	yield Promise.resolve();
+});
+
+task.default(async function* () {
+	yield Promise.resolve();
+});
+
+task.keepLatest(async function* () {
+	yield Promise.resolve();
+});
+
+task.restart(async function* () {
+	yield Promise.resolve();
+});

--- a/src/lib/tests/expected-transforms/generate-expected.ts
+++ b/src/lib/tests/expected-transforms/generate-expected.ts
@@ -1,5 +1,5 @@
 import { asyncTransform } from '../../vite';
-import { readdirSync } from 'node:fs';
+import { readdirSync, existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 
 const dir = readdirSync('./src/lib/tests/expected-transforms', {
@@ -7,15 +7,22 @@ const dir = readdirSync('./src/lib/tests/expected-transforms', {
 	recursive: true,
 });
 
+const [, , force] = process.argv;
+
 const plugin = asyncTransform();
 
 for (const file of dir) {
-	if (file.isFile() && file.name === 'code.js') {
-		readFile(`${file.path}/${file.name}`).then(async (code) => {
+	if (
+		file.isFile() &&
+		file.name === 'code.js' &&
+		(!!force || !existsSync(`${file.parentPath}/transform.js`))
+	) {
+		console.log('generating expected for', file.parentPath);
+		readFile(`${file.parentPath}/${file.name}`).then(async (code) => {
 			// @ts-expect-error we don't have the correct `this` here but we are not using it
 			const result = await plugin.transform(code, 'code.js');
 			if (result) {
-				await writeFile(`${file.path}/transform.js`, result.code);
+				await writeFile(`${file.parentPath}/transform.js`, result.code);
 			}
 		});
 	}

--- a/src/lib/tests/expected-transforms/with-options/code.js
+++ b/src/lib/tests/expected-transforms/with-options/code.js
@@ -1,0 +1,21 @@
+import { task } from "@sheepdog/svelte";
+
+task(async () => {
+	await Promise.resolve();
+}, {kind: "drop", max: 3});
+
+task(async () => {
+	await Promise.resolve();
+}, {kind: "enqueue", max: 3});
+
+task(async () => {
+	await Promise.resolve();
+}, {kind: "default", max: 3});
+
+task(async () => {
+	await Promise.resolve();
+}, {kind: "keepLatest", max: 3});
+
+task(async () => {
+	await Promise.resolve();
+}, {kind: "restart", max: 3});

--- a/src/lib/tests/expected-transforms/with-options/transform.js
+++ b/src/lib/tests/expected-transforms/with-options/transform.js
@@ -1,0 +1,36 @@
+import { task } from "@sheepdog/svelte";
+
+task(
+	async function* () {
+		yield Promise.resolve();
+	},
+	{ kind: "drop", max: 3 }
+);
+
+task(
+	async function* () {
+		yield Promise.resolve();
+	},
+	{ kind: "enqueue", max: 3 }
+);
+
+task(
+	async function* () {
+		yield Promise.resolve();
+	},
+	{ kind: "default", max: 3 }
+);
+
+task(
+	async function* () {
+		yield Promise.resolve();
+	},
+	{ kind: "keepLatest", max: 3 }
+);
+
+task(
+	async function* () {
+		yield Promise.resolve();
+	},
+	{ kind: "restart", max: 3 }
+);

--- a/src/lib/tests/task.test.ts
+++ b/src/lib/tests/task.test.ts
@@ -121,7 +121,7 @@ describe.each([
 			const perform = getByTestId(`perform-${selector}`);
 			const cancel = getByTestId(`cancel-${selector}`);
 			perform.click();
-			await timeout(20);
+			await vi.advanceTimersByTimeAsync(20);
 			cancel.click();
 			await vi.waitFor(() => {
 				expect(task_signal.aborted).toBeTruthy();
@@ -149,7 +149,7 @@ describe.each([
 			const perform = getByTestId(`perform-${selector}`);
 			const cancel = getByTestId(`cancel-${selector}-last`);
 			perform.click();
-			await timeout(20);
+			await vi.advanceTimersByTimeAsync(20);
 			cancel.click();
 			await vi.waitFor(() => {
 				expect(task_signal.aborted).toBeTruthy();
@@ -177,7 +177,7 @@ describe.each([
 			const perform = getByTestId(`perform-${selector}`);
 			const cancel = getByTestId(`cancel-${selector}`);
 			perform.click();
-			await timeout(20);
+			await vi.advanceTimersByTimeAsync(20);
 			cancel.click();
 			await vi.waitFor(() => {
 				expect(task_signal.aborted).toBeTruthy();
@@ -252,13 +252,13 @@ describe.each([
 			const store = instance[`${selector}_task`] as Task;
 			const perform = getByTestId(`perform-${selector}`);
 			perform.click();
-			await timeout(10);
+			await vi.advanceTimersByTimeAsync(10);
 			perform.click();
-			await timeout(10);
+			await vi.advanceTimersByTimeAsync(10);
 			perform.click();
-			await timeout(10);
+			await vi.advanceTimersByTimeAsync(10);
 			perform.click();
-			await timeout(10);
+			await vi.advanceTimersByTimeAsync(10);
 			perform.click();
 			await vi.waitFor(
 				() => {
@@ -531,7 +531,7 @@ describe("task - specific functionality 'default'", () => {
 			await vi.waitFor(() => {
 				expect(task_signals[2].aborted).toBeTruthy();
 			});
-			await timeout(wait_time);
+			await vi.advanceTimersByTimeAsync(wait_time);
 			expect(count).toBe(2);
 		});
 	});
@@ -612,7 +612,7 @@ describe("task - specific functionality 'enqueue'", () => {
 			await vi.waitFor(() => {
 				expect(task_signals[2].aborted).toBeTruthy();
 			});
-			await timeout(wait_time);
+			await vi.advanceTimersByTimeAsync(wait_time);
 			expect(count).toBe(2);
 		});
 	});

--- a/src/lib/tests/utils.test.ts
+++ b/src/lib/tests/utils.test.ts
@@ -17,6 +17,7 @@ describe('Util - didCancel', () => {
 
 describe('Util - timeout', () => {
 	it('correctly resolves timeout 0', async () => {
+		vi.useRealTimers();
 		let result = false;
 		timeout(0).then(() => (result = true));
 		expect(result).toBe(false);

--- a/src/lib/vite.ts
+++ b/src/lib/vite.ts
@@ -203,7 +203,12 @@ export function asyncTransform() {
 						},
 						CallExpression(node, { state, next }) {
 							state.task_fn_name.then((name) => {
-								if (node.callee.type === 'Identifier' && node.callee.name === name) {
+								if (
+									(node.callee.type === 'Identifier' && node.callee.name === name) ||
+									(node.callee.type === 'MemberExpression' &&
+										node.callee.object.type === 'Identifier' &&
+										node.callee.object.name === name)
+								) {
 									const task_arg = node.arguments[0];
 									if (task_arg && task_arg.type === 'ArrowFunctionExpression' && task_arg.async) {
 										const to_change = task_arg as unknown as FunctionExpression;

--- a/src/vitest-setup.ts
+++ b/src/vitest-setup.ts
@@ -1,2 +1,11 @@
 import '@testing-library/svelte/vitest';
 import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, vi } from 'vitest';
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});


### PR DESCRIPTION
Closes #136 

I also made some change to the expected generated script to avoid overriding old values unless you pass -f as an argument. This is because technically the rest should still be working as before unless we make a breaking change and in that case we can force.