### PR TITLE
fix: avoid changing state of successful task to cancelled

### DIFF
--- a/src/lib/tests/components/default.svelte
+++ b/src/lib/tests/components/default.svelte
@@ -12,6 +12,9 @@
 	export const default_task = task.default(fn);
 	export const options_task = task(fn, { kind: 'default' });
 
+	export const default_instances: Array<ReturnType<typeof default_task.perform>> = [];
+	export const options_instances: Array<ReturnType<typeof options_task.perform>> = [];
+
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
 	let latest_options_task_instance: ReturnType<typeof options_task.perform>;
 </script>
@@ -21,6 +24,7 @@
 	on:click={async () => {
 		try {
 			latest_task_instance = default_task.perform(argument);
+			default_instances.push(latest_task_instance);
 			return_value(await latest_task_instance);
 		} catch {
 			/**empty*/
@@ -33,6 +37,7 @@
 	on:click={async () => {
 		try {
 			latest_options_task_instance = options_task.perform(argument);
+			options_instances.push(latest_options_task_instance);
 			return_value(await latest_options_task_instance);
 		} catch {
 			/**empty*/

--- a/src/lib/tests/components/drop.svelte
+++ b/src/lib/tests/components/drop.svelte
@@ -13,6 +13,9 @@
 	export const default_task = task.drop(fn, { max });
 	export const options_task = task(fn, { kind: 'drop', max });
 
+	export const default_instances: Array<ReturnType<typeof default_task.perform>> = [];
+	export const options_instances: Array<ReturnType<typeof options_task.perform>> = [];
+
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
 	let latest_options_task_instance: ReturnType<typeof options_task.perform>;
 </script>
@@ -22,6 +25,7 @@
 	on:click={async () => {
 		try {
 			latest_task_instance = default_task.perform(argument);
+			default_instances.push(latest_task_instance);
 			return_value(await latest_task_instance);
 		} catch {
 			/**empty*/
@@ -34,6 +38,7 @@
 	on:click={async () => {
 		try {
 			latest_options_task_instance = options_task.perform(argument);
+			options_instances.push(latest_options_task_instance);
 			return_value(await latest_options_task_instance);
 		} catch {
 			/**empty*/

--- a/src/lib/tests/components/enqueue.svelte
+++ b/src/lib/tests/components/enqueue.svelte
@@ -13,8 +13,8 @@
 	export const default_task = task.enqueue(fn, { max });
 	export const options_task = task(fn, { kind: 'enqueue', max });
 
-	export const get_latest_default_task_instance = () => latest_task_instance;
-	export const get_latest_options_task_instance = () => latest_options_task_instance;
+	export const default_instances: Array<ReturnType<typeof default_task.perform>> = [];
+	export const options_instances: Array<ReturnType<typeof options_task.perform>> = [];
 
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
 	let latest_options_task_instance: ReturnType<typeof options_task.perform>;
@@ -25,6 +25,7 @@
 	on:click={async () => {
 		try {
 			latest_task_instance = default_task.perform(argument);
+			default_instances.push(latest_task_instance);
 			return_value(await latest_task_instance);
 		} catch {
 			/**empty*/
@@ -37,6 +38,7 @@
 	on:click={async () => {
 		try {
 			latest_options_task_instance = options_task.perform(argument);
+			options_instances.push(latest_options_task_instance);
 			return_value(await latest_options_task_instance);
 		} catch {
 			/**empty*/

--- a/src/lib/tests/components/keep_latest.svelte
+++ b/src/lib/tests/components/keep_latest.svelte
@@ -13,6 +13,9 @@
 	export const default_task = task.keepLatest(fn, { max });
 	export const options_task = task(fn, { kind: 'keepLatest', max });
 
+	export const default_instances: Array<ReturnType<typeof default_task.perform>> = [];
+	export const options_instances: Array<ReturnType<typeof options_task.perform>> = [];
+
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
 	let latest_options_task_instance: ReturnType<typeof options_task.perform>;
 </script>
@@ -22,6 +25,7 @@
 	on:click={async () => {
 		try {
 			latest_task_instance = default_task.perform(argument);
+			default_instances.push(latest_task_instance);
 			return_value(await latest_task_instance);
 		} catch {
 			/**empty*/
@@ -34,6 +38,7 @@
 	on:click={async () => {
 		try {
 			latest_options_task_instance = options_task.perform(argument);
+			options_instances.push(latest_options_task_instance);
 			return_value(await latest_options_task_instance);
 		} catch {
 			/**empty*/

--- a/src/lib/tests/components/restart.svelte
+++ b/src/lib/tests/components/restart.svelte
@@ -13,6 +13,9 @@
 	export const default_task = task.restart(fn, { max });
 	export const options_task = task(fn, { kind: 'restart', max });
 
+	export const default_instances: Array<ReturnType<typeof default_task.perform>> = [];
+	export const options_instances: Array<ReturnType<typeof options_task.perform>> = [];
+
 	let latest_task_instance: ReturnType<typeof default_task.perform>;
 	let latest_options_task_instance: ReturnType<typeof options_task.perform>;
 </script>
@@ -22,6 +25,7 @@
 	on:click={async () => {
 		try {
 			latest_task_instance = default_task.perform(argument);
+			default_instances.push(latest_task_instance);
 			return_value(await latest_task_instance);
 		} catch {
 			/**empty*/
@@ -34,6 +38,7 @@
 	on:click={async () => {
 		try {
 			latest_options_task_instance = options_task.perform(argument);
+			options_instances.push(latest_options_task_instance);
 			return_value(await latest_options_task_instance);
 		} catch {
 			/** empty */

--- a/src/lib/tests/task.test.ts
+++ b/src/lib/tests/task.test.ts
@@ -370,7 +370,7 @@ describe.each([
 			});
 		});
 
-		it("after an instance has completed calling cancelAll doesn't change it's `isCancelled` status", async () => {
+		it("after an instance has completed calling `cancelAll` doesn't change its `isCancelled` status", async () => {
 			const fn = vi.fn(async () => {
 				await timeout(50);
 			});
@@ -390,6 +390,24 @@ describe.each([
 			expect(instances[0].get().isCanceled).toBeFalsy();
 			expect(instances[1].get().isSuccessful).toBeFalsy();
 			expect(instances[1].get().isCanceled).toBeTruthy();
+		});
+
+		it("after an instance has completed calling `cancel` doesn't change its `isCancelled` status", async () => {
+			const fn = vi.fn(async () => {
+				await timeout(50);
+			});
+			const { getByTestId, component: instance } = render(component, {
+				fn,
+			});
+			const instances = instance[`${selector}_instances`] as Array<ReturnType<Task['perform']>>;
+			const perform = getByTestId(`perform-${selector}`);
+			const cancel = getByTestId(`cancel-${selector}-last`);
+			perform.click();
+			await vi.waitFor(() => expect(fn).toHaveBeenCalled());
+			await vi.waitFor(() => expect(instances[0].get().isSuccessful).toBeTruthy());
+			cancel.click();
+			expect(instances[0].get().isSuccessful).toBeTruthy();
+			expect(instances[0].get().isCanceled).toBeFalsy();
 		});
 	});
 


### PR DESCRIPTION
Closes #135 

I've also updated your tests @beerinho because it was still better to do it this way 😄 