### PR TITLE
Add Tabs component

### DIFF
--- a/apps/docs/src/components/Tabs.svelte
+++ b/apps/docs/src/components/Tabs.svelte
@@ -1,0 +1,45 @@
+<script>
+</script>
+
+<div class="wrapper">
+	<slot />
+</div>
+
+<style>
+	.wrapper {
+		display: inline-flex;
+		align-items: center;
+		border-radius: calc(1rem + 5px);
+		border: 4px var(--sheepdog-primary) solid;
+	}
+
+	.wrapper > :global(button) {
+		margin: 0;
+		background-color: transparent;
+		border: none;
+		outline: none;
+		min-width: 5rem;
+		cursor: pointer;
+		padding: 0.25rem 1rem;
+		border-radius: 1rem;
+		color: var(--sheepdog-primary);
+	}
+
+	.wrapper > :global(.active) {
+		background-color: var(--sheepdog-primary);
+		color: var(--sl-color-black);
+	}
+
+	:global([data-theme='dark']) .wrapper {
+		border: 4px var(--sl-color-white) solid;
+	}
+
+	:global([data-theme='dark']) .wrapper > :global(.active) {
+		background-color: var(--sl-color-white);
+		color: var(--sl-color-black);
+	}
+
+	:global([data-theme='dark']) .wrapper > :global(button) {
+		color: var(--sl-color-white);
+	}
+</style>

--- a/apps/docs/src/content/docs/Example.svelte
+++ b/apps/docs/src/content/docs/Example.svelte
@@ -1,11 +1,20 @@
 <script>
 	import { task, didCancel } from '@sheepdog/svelte';
 	import Timeline from './Timeline.svelte';
+	import Tabs from '../../components/Tabs.svelte';
 
 	let elements = [];
 	let start;
 
 	let selectedTaskType = 'enqueue';
+
+	const modifierTypes = [
+		{ label: 'Enqueue', value: 'enqueue' },
+		{ label: 'Drop', value: 'drop' },
+		{ label: 'Restart', value: 'restart' },
+		{ label: 'Keep Latest', value: 'keepLatest' },
+		{ label: 'Default', value: 'default' },
+	];
 
 	async function* fn({ to_add, now }) {
 		to_add.start = Date.now() - now;
@@ -25,13 +34,13 @@
 	};
 </script>
 
-<div>
-	<button on:click={() => setTaskType('enqueue')}>Enqueue</button>
-	<button on:click={() => setTaskType('drop')}>Drop</button>
-	<button on:click={() => setTaskType('restart')}>Restart</button>
-	<button on:click={() => setTaskType('keepLatest')}>Keep Latest</button>
-	<button on:click={() => setTaskType('default')}>Default</button>
-</div>
+<Tabs>
+	{#each modifierTypes as type}
+		<button on:click={() => setTaskType(type.value)} class:active={selectedTaskType === type.value}
+			>{type.label}</button
+		>
+	{/each}
+</Tabs>
 <p>You can click an individual task instance to cancel it</p>
 
 <button


### PR DESCRIPTION
This PR adds the Tabs component which is simply a styling wrapper that can wrap a number of buttons and it will add the styles to turn them into a line of "tabs" the only important distinction is that the active button needs to have the "active" class set

<img width="483" alt="image" src="https://github.com/user-attachments/assets/174b2306-87d7-4fc3-be22-4fdab1cd969e">

Closes #161 