### PR TITLE
Add SheepdogUtils & Linked task docs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -112,6 +112,10 @@ export default defineConfig({
 							link: '/reference/restart',
 						},
 						{
+							label: 'Sheepdog Utils',
+							link: '/reference/sheepdog-utils',
+						},
+						{
 							label: 'Task Instance',
 							link: '/reference/task-instance',
 						},

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -83,6 +83,10 @@ export default defineConfig({
 							link: '/explainers/task-modifiers/',
 						},
 						{
+							label: 'Linking tasks',
+							link: '/explainers/linking-tasks/',
+						},
+						{
 							label: 'Async Transform',
 							link: '/explainers/async-transform/',
 						},

--- a/apps/docs/src/content/docs/explainers/linking-tasks.mdx
+++ b/apps/docs/src/content/docs/explainers/linking-tasks.mdx
@@ -1,0 +1,78 @@
+---
+title: Linking Tasks
+description: How to bind tasks together for simpler cancellation
+---
+
+### Motivation
+
+Breaking up asynchronous calls into bitesize chunks makes a lot of sense: it's easier to reason about, it allows us to show different states depending on what stage of the call we are in, and it helps us organize our code better.
+
+But the biggest issue this exposes that it is very difficult to cancel all children if the parent is cancelled.
+
+Imagine this scenario: we're creating a blog feed widget that will get all of the user's posts and comments and show them in a small box somewhere on the page. We might have something like this to load all of those posts and comments:
+
+```js 
+async function fetch(){
+  // make first call
+  const user = await fetchUser()
+  // make second call based on first response
+  const posts = await fetchUserPosts(user)
+  // make third call based on first and second responses
+  return await fetchPostComments({user, posts})
+}
+
+async function fetchUser(){
+  // returns user stuff
+}
+
+async function fetchUserPosts(user){
+  // returns user's posts
+}
+
+async function fetchPostComments({user, posts}){
+  // returns posts' comments
+}
+```
+
+Now this is great, it's been neatly enclosed in a component so that the rest of the page doesn't need to be blocked while waiting for this widget to load. We could also include some logic to enable us to show which call is currently being run.
+
+But what would happen if the user navigated away or destroyed between the initial call and the final result? Our API would still receive those requests and go and do all of the work to get the data and return it but we are no longer using the returned data or even have a reference to it in our app. This kind of scenario can very easily cause data leaks that can gradually bring our app down.
+
+_If only there was a way to link these calls together._
+
+### Solution
+
+Well, we heard your cries and created the `link` function.
+
+`Link` is one of two [SheepdogUtils](/reference/sheepdog-utils) and it enables us to link a child task to its parent so that the lifecycle of the child task is directly bound to the lifecycle of its parent. That means that if the parent is canceled, the child is automatically aborted.
+
+Turning our above scenario into tasks would look like this:
+
+```js 
+import { task } from "@sheepdog/svelte"
+
+fetch = task(async (_, { link }) => {
+  // make first call
+  const user = await link(fetchUser).perform();
+  // make second call based on first response
+  const posts = await link(fetchUserPosts).perform(user)
+  // make third call based on first and second responses
+  return await link(fetchPostComments).perform({user, posts})
+})
+
+fetchUser = task(async () => {
+  // returns user stuff
+})
+
+fetchUserPosts = task(async (user) => {
+  // returns user's posts
+})
+
+fetchPostComments = task(async ({user, posts}) => {
+  // returns posts' comments
+})
+```
+
+And now all of our child tasks are bound to the parent context, meaning if the context that the parent task lives on is destroyed, all of the other tasks will be cancelled.
+
+Another added benefit of this is that we already have the different loading states out of the box, we could simply see which task is running and be able to show each loading state individually.

--- a/apps/docs/src/content/docs/reference/default.mdx
+++ b/apps/docs/src/content/docs/reference/default.mdx
@@ -71,7 +71,7 @@ by the `perform` function (and it will be strongly typed too).
 
 <Aside type="caution">
 	If you need to pass multiple props you should use an object because the second parameter will
-	always be the [SheepdogOptions](#).
+	always be the [SheepdogUtils](/reference/sheepdog-utils).
 </Aside>
 
 <Tabs syncKey="notation">

--- a/apps/docs/src/content/docs/reference/drop.mdx
+++ b/apps/docs/src/content/docs/reference/drop.mdx
@@ -110,7 +110,7 @@ by the `perform` function (and it will be strongly typed too).
 
 <Aside type="caution">
 	If you need to pass multiple props you should use an object because the second parameter will
-	always be the [SheepdogOptions](#).
+	always be the [SheepdogUtils](/reference/sheepdog-utils).
 </Aside>
 
 <Tabs syncKey="notation">

--- a/apps/docs/src/content/docs/reference/enqueue.mdx
+++ b/apps/docs/src/content/docs/reference/enqueue.mdx
@@ -110,7 +110,7 @@ by the `perform` function (and it will be strongly typed too).
 
 <Aside type="caution">
 	If you need to pass multiple props you should use an object because the second parameter will
-	always be the [SheepdogOptions](#).
+	always be the [SheepdogUtils](/reference/sheepdog-utils).
 </Aside>
 
 <Tabs syncKey="notation">

--- a/apps/docs/src/content/docs/reference/keep-latest.mdx
+++ b/apps/docs/src/content/docs/reference/keep-latest.mdx
@@ -118,7 +118,7 @@ by the `perform` function (and it will be strongly typed too).
 
 <Aside type="caution">
 	If you need to pass multiple props you should use an object because the second parameter will
-	always be the [SheepdogOptions](#).
+	always be the [SheepdogUtils](/reference/sheepdog-utils).
 </Aside>
 
 <Tabs syncKey="notation">

--- a/apps/docs/src/content/docs/reference/restart.mdx
+++ b/apps/docs/src/content/docs/reference/restart.mdx
@@ -110,7 +110,7 @@ by the `perform` function (and it will be strongly typed too).
 
 <Aside type="caution">
 	If you need to pass multiple props you should use an object because the second parameter will
-	always be the [SheepdogOptions](#).
+	always be the [SheepdogUtils](/reference/sheepdog-utils).
 </Aside>
 
 <Tabs syncKey="notation">

--- a/apps/docs/src/content/docs/reference/sheepdog-utils.mdx
+++ b/apps/docs/src/content/docs/reference/sheepdog-utils.mdx
@@ -1,0 +1,30 @@
+---
+title: Sheepdog Utils
+description: the utilities object that is available in every task
+---
+
+When creating a task (of any type) there are 2 possible arguments that be accessed, the first is any argument that is passed in when calling `.perform()`, and the second is an object that can be used to extend your task - `SheepdogUtils`.
+
+`SheepdogUtils` offers two properties to extend your task with:
+- `signal` - the `AbortSignal` is available so that you can do any further manipulation you need based on the state of the `AbortSignal`. We won't go into too much detail about this as it is the standard `AbortSignal` interface that is simply passed back from `Sheepdog`.
+- `link` - this is a `Sheepdog` specific function that allows you to bind tasks together. For more information, check out the [Linking Tasks explainer](/explainer/linking-tasks).
+
+```svelte
+<script lang="ts">
+	import { task, type SheepdogUtils } from '@sheepdog/svelte';
+
+	const myTask = task(async (myArgument: any, {signal, link}: SheepdogUtils) => {
+		// your code
+	});
+</script>
+```
+
+```ts
+type SheepdogUtils = {
+	signal: AbortSignal;
+	link: <TArgs, TReturn>(task: Task<TArgs, TReturn>) => Task<TArgs, TReturn>;
+};
+```
+
+
+

--- a/apps/docs/src/content/docs/reference/sheepdog-utils.mdx
+++ b/apps/docs/src/content/docs/reference/sheepdog-utils.mdx
@@ -3,7 +3,7 @@ title: Sheepdog Utils
 description: the utilities object that is available in every task
 ---
 
-When creating a task (of any type) there are 2 possible arguments that be accessed, the first is any argument that is passed in when calling `.perform()`, and the second is an object that can be used to extend your task - `SheepdogUtils`.
+When creating a task (of any type) there are 2 possible arguments that can be accessed, the first is any argument that is passed in when calling `.perform()`, and the second is an object that can be used to optionally enhance your task - `SheepdogUtils`.
 
 `SheepdogUtils` offers two properties to extend your task with:
 - `signal` - the `AbortSignal` is available so that you can do any further manipulation you need based on the state of the `AbortSignal`. We won't go into too much detail about this as it is the standard `AbortSignal` interface that is simply passed back from `Sheepdog`.
@@ -11,9 +11,9 @@ When creating a task (of any type) there are 2 possible arguments that be access
 
 ```svelte
 <script lang="ts">
-	import { task, type SheepdogUtils } from '@sheepdog/svelte';
+	import { task } from '@sheepdog/svelte';
 
-	const myTask = task(async (myArgument: any, {signal, link}: SheepdogUtils) => {
+	const myTask = task(async (myArgument, {signal, link}) => {
 		// your code
 	});
 </script>


### PR DESCRIPTION
This PR adds an explainer for linked tasks, and a reference for SheepdogUtils (it was also incorrectly named "SheepdogOptions" in the docs so that has been finished now)

Closes #175 
Closes #176 