### PR TITLE
fix: way better async transform

### DIFF
--- a/packages/svelte/src/lib/tests/expected-transforms/add-yield-after-await-assignment/code.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/add-yield-after-await-assignment/code.js
@@ -8,6 +8,11 @@ function fn(val) {
 }
 
 /**
+ * @type {Record<string,()=>void>}
+ */
+const fns = {};
+
+/**
  * 
  * @param {TemplateStringsArray} quasi 
  * @param {string} strings 
@@ -21,6 +26,8 @@ task(async () => {
 	const array = [await Promise.resolve()];
 	const sum = await Promise.resolve(1) + 2;
 	const sum2 = 2 + await Promise.resolve(1);
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined]
 	const function_call = fn(await Promise.resolve(2));
 	const conditional1 = await Promise.resolve(true) ? 1 : 2;
 	const conditional2 = true ? await Promise.resolve(1) : 2;

--- a/packages/svelte/src/lib/tests/expected-transforms/add-yield-after-await-assignment/transform.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/add-yield-after-await-assignment/transform.js
@@ -4,6 +4,8 @@ function fn(val) {
 	return val;
 }
 
+const fns = {};
+
 function str(quasi, strings) {}
 
 task(async function* () {
@@ -15,6 +17,13 @@ task(async function* () {
 	const array = [yield Promise.resolve()];
 	const sum = (yield Promise.resolve(1)) + 2;
 	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
 	const function_call = fn(yield Promise.resolve(2));
 	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
 	const conditional2 = true ? yield Promise.resolve(1) : 2;

--- a/packages/svelte/src/lib/tests/expected-transforms/statements-in-blocks/transform.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/statements-in-blocks/transform.js
@@ -73,7 +73,7 @@ task(async function* () {
 	}
 
 	{
-		console.log(await Promise.resolve(false));
+		console.log(yield Promise.resolve(false));
 	}
 
 	if (yield Promise.resolve(true)) console.log(yield Promise.resolve(true));

--- a/packages/svelte/src/lib/vite.ts
+++ b/packages/svelte/src/lib/vite.ts
@@ -1,170 +1,23 @@
+import type {
+	ArrowFunctionExpression,
+	AwaitExpression,
+	BlockStatement,
+	CallExpression,
+	FunctionExpression,
+	ImportDeclaration,
+} from 'acorn';
+import { parse } from 'acorn';
+import { print } from 'esrap';
 import type { Plugin } from 'vite';
 import { walk } from 'zimmerframe';
-import { print } from 'esrap';
-import { parse } from 'acorn';
-import type {
-	ImportDeclaration,
-	FunctionExpression,
-	ArrowFunctionExpression,
-	CallExpression,
-	Expression,
-	YieldExpression,
-	BlockStatement,
-	Statement,
-} from 'acorn';
 
-type Nodes = ImportDeclaration | FunctionExpression | ArrowFunctionExpression | CallExpression;
-
-/**
- * This should handle most situation where you can top level await in an async function
- */
-function get_expressions_await(expression: Expression): Expression[] {
-	switch (expression.type) {
-		case 'ArrayExpression':
-			// const x = [await promise];
-			return expression.elements.flatMap((element) =>
-				element?.type !== 'SpreadElement' && element !== null ? get_expressions_await(element) : [],
-			);
-		case 'AssignmentExpression':
-			// x = await promise; x = { value: await promise }; x = [await promise]
-			// TODO: [x = await promise] = [undefined]
-			return get_expressions_await(expression.right).concat(
-				expression.left.type === 'MemberExpression' ? get_expressions_await(expression.left) : [],
-			);
-		case 'AwaitExpression':
-			// await promise;
-			return [expression];
-		case 'BinaryExpression':
-			// await promise + something;
-			if (expression.left.type !== 'PrivateIdentifier') {
-				return get_expressions_await(expression.left).concat(
-					get_expressions_await(expression.right),
-				);
-			}
-			return get_expressions_await(expression.right);
-		case 'CallExpression':
-			// fn_call(await stuff);
-			// TODO: fns[await name]();
-			return expression.arguments.flatMap((argument) =>
-				argument.type !== 'SpreadElement' ? get_expressions_await(argument) : [],
-			);
-		case 'ConditionalExpression':
-			// await test ? await consequent : await alternate;
-			return get_expressions_await(expression.alternate)
-				.concat(get_expressions_await(expression.consequent))
-				.concat(get_expressions_await(expression.test));
-		case 'LogicalExpression':
-			// await promise || await another;
-			return get_expressions_await(expression.left).concat(get_expressions_await(expression.right));
-		case 'MemberExpression':
-			return expression.property.type !== 'PrivateIdentifier'
-				? get_expressions_await(expression.property)
-				: [];
-		case 'ObjectExpression':
-			return expression.properties.flatMap((property) =>
-				property.type !== 'SpreadElement'
-					? get_expressions_await(property.key).concat(get_expressions_await(property.value))
-					: [],
-			);
-		case 'TaggedTemplateExpression':
-			return get_expressions_await(expression.quasi);
-		case 'TemplateLiteral':
-			return expression.expressions.flatMap((template_expression) =>
-				get_expressions_await(template_expression),
-			);
-		case 'UnaryExpression':
-			return get_expressions_await(expression.argument);
-		default:
-			return [];
-	}
-}
-
-function to_fake_block_statement(statement: Statement) {
-	return {
-		body: [statement],
-		type: 'BlockStatement' as const,
-		end: 0,
-		start: 0,
-	};
-}
-
-function update_body(task: BlockStatement) {
-	for (const statement of task.body) {
-		let expressions: Expression[] = [];
-		if (statement.type === 'ExpressionStatement') {
-			expressions = get_expressions_await(statement.expression);
-		} else if (statement.type === 'VariableDeclaration') {
-			for (const declaration of statement.declarations) {
-				if (declaration.init) {
-					expressions = expressions.concat(get_expressions_await(declaration.init));
-				}
-			}
-		} else if (
-			statement.type === 'ForInStatement' ||
-			statement.type === 'ForOfStatement' ||
-			statement.type === 'WhileStatement' ||
-			statement.type === 'DoWhileStatement' ||
-			statement.type === 'ForStatement' ||
-			statement.type === 'LabeledStatement'
-		) {
-			if (statement.body.type === 'BlockStatement') {
-				update_body(statement.body);
-			} else if (statement.body.type === 'ExpressionStatement') {
-				expressions = expressions.concat(get_expressions_await(statement.body.expression));
-			}
-			if (statement.type === 'ForInStatement' || statement.type === 'ForOfStatement') {
-				expressions = expressions.concat(get_expressions_await(statement.right));
-			} else if (statement.type === 'ForStatement') {
-				if (statement.init && statement.init.type !== 'VariableDeclaration') {
-					expressions = expressions.concat(get_expressions_await(statement.init));
-				} else if (statement.init) {
-					update_body(to_fake_block_statement(statement.init));
-				}
-				if (statement.test) {
-					expressions = expressions.concat(get_expressions_await(statement.test));
-				}
-				if (statement.update) {
-					expressions = expressions.concat(get_expressions_await(statement.update));
-				}
-			} else if (statement.type === 'WhileStatement' || statement.type === 'DoWhileStatement') {
-				expressions = expressions.concat(get_expressions_await(statement.test));
-			}
-		} else if (statement.type === 'IfStatement') {
-			if (statement.consequent.type === 'BlockStatement') {
-				update_body(statement.consequent);
-			} else if (statement.consequent.type === 'ExpressionStatement') {
-				expressions = expressions.concat(get_expressions_await(statement.consequent.expression));
-			}
-			expressions = expressions.concat(get_expressions_await(statement.test));
-			if (statement.alternate?.type === 'ExpressionStatement') {
-				expressions = expressions.concat(get_expressions_await(statement.alternate.expression));
-			} else if (statement.alternate) {
-				update_body(to_fake_block_statement(statement.alternate));
-			}
-		} else if (statement.type === 'SwitchStatement') {
-			for (const switch_case of statement.cases) {
-				for (const consequent of switch_case.consequent) {
-					if (consequent.type === 'BlockStatement') {
-						update_body(consequent);
-					} else if (consequent.type === 'ExpressionStatement') {
-						expressions = expressions.concat(get_expressions_await(consequent.expression));
-					}
-				}
-				if (switch_case.test) {
-					expressions = expressions.concat(get_expressions_await(switch_case.test));
-				}
-			}
-			if (statement.discriminant) {
-				expressions = expressions.concat(get_expressions_await(statement.discriminant));
-			}
-		}
-		for (const expression of expressions) {
-			if (expression.type === 'AwaitExpression') {
-				(expression as unknown as YieldExpression).type = 'YieldExpression';
-			}
-		}
-	}
-}
+type Nodes =
+	| ImportDeclaration
+	| FunctionExpression
+	| ArrowFunctionExpression
+	| CallExpression
+	| BlockStatement
+	| AwaitExpression;
 
 export function asyncTransform() {
 	return {
@@ -176,16 +29,11 @@ export function asyncTransform() {
 					locations: true,
 					sourceType: 'module',
 				});
-				let resolve_fn_name: (value: string | undefined | PromiseLike<string>) => void;
-				const task_fn_name = new Promise<string | undefined>((resolve) => {
-					resolve_fn_name = resolve;
-				});
-				let changed = false;
-				const returned = walk(
-					ast as unknown as Nodes,
-					{
-						task_fn_name,
-					},
+				let fn_name: string;
+				// let's walk once to find the name (we were using a promise before but that's just messy)
+				walk(
+					ast as unknown as ImportDeclaration,
+					{},
 					{
 						ImportDeclaration(node) {
 							if (node.source.value === '@sheepdog/svelte') {
@@ -197,44 +45,60 @@ export function asyncTransform() {
 									);
 								});
 								if (task_fn && task_fn.type === 'ImportSpecifier') {
-									resolve_fn_name(task_fn.local.name);
+									fn_name = task_fn.local.name;
 								}
 							}
 						},
+					},
+				);
+				let changed = false;
+				const returned = walk(
+					ast as unknown as Nodes,
+					{
+						transform: false,
+					},
+					{
+						AwaitExpression(node, { next, state }) {
+							if (state.transform) {
+								next();
+								node.type = 'YieldExpression' as never;
+							}
+						},
 						CallExpression(node, { state, next }) {
-							state.task_fn_name.then((name) => {
-								if (
-									(node.callee.type === 'Identifier' && node.callee.name === name) ||
-									(node.callee.type === 'MemberExpression' &&
-										node.callee.object.type === 'Identifier' &&
-										node.callee.object.name === name)
+							let local_changed = false;
+							if (
+								(node.callee.type === 'Identifier' && node.callee.name === fn_name) ||
+								(node.callee.type === 'MemberExpression' &&
+									node.callee.object.type === 'Identifier' &&
+									node.callee.object.name === fn_name)
+							) {
+								const task_arg = node.arguments[0];
+								if (task_arg && task_arg.type === 'ArrowFunctionExpression' && task_arg.async) {
+									const to_change = task_arg as unknown as FunctionExpression;
+									to_change.type = 'FunctionExpression';
+									to_change.generator = true;
+									next({ ...state, transform: true });
+									changed = true;
+									local_changed = true;
+								} else if (
+									task_arg &&
+									task_arg.type === 'FunctionExpression' &&
+									!task_arg.generator &&
+									task_arg.async
 								) {
-									const task_arg = node.arguments[0];
-									if (task_arg && task_arg.type === 'ArrowFunctionExpression' && task_arg.async) {
-										const to_change = task_arg as unknown as FunctionExpression;
-										to_change.type = 'FunctionExpression';
-										to_change.generator = true;
-										update_body(to_change.body);
-										changed = true;
-									} else if (
-										task_arg &&
-										task_arg.type === 'FunctionExpression' &&
-										!task_arg.generator &&
-										task_arg.async
-									) {
-										const to_change = task_arg as unknown as FunctionExpression;
-										to_change.generator = true;
-										update_body(to_change.body);
-										changed = true;
-									}
+									const to_change = task_arg as unknown as FunctionExpression;
+									to_change.generator = true;
+									next({ ...state, transform: true });
+									changed = true;
+									local_changed = true;
 								}
-							});
-							next();
+							}
+							if (!local_changed) {
+								next();
+							}
 						},
 					},
 				) as unknown as typeof ast;
-				resolve_fn_name!(undefined);
-				await task_fn_name;
 
 				if (changed) {
 					return {


### PR DESCRIPTION
During lunch i had an epiphany...we were doing a lot of manual work in the async transform but it was way simpler to delegate that work to `zimmerframe`...i also removed the async search of the name which (strangely for async code /s) was adding complexity while we could just search sync (we need to walk twice but the overhead is minimal).