### PR TITLE
add corepack to fix netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
 		"patchedDependencies": {
 			"fixturify-project": "patches/fixturify-project.patch"
 		}
-	}
+	},
+	"packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4"
 }


### PR DESCRIPTION
Turns out that netlify has been using pnpm@8 to install stuff 🫠 

> Installing npm packages using pnpm version 8.15.8

This adds a packageManager line to the pakcage.json for netlify (and people using corepack) to use the right pnpm 👍 