### PR TITLE
feat: add utils export

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -10,13 +10,18 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"import": "./dist/index.js"
 		},
 		"./task": {
 			"types": "./dist/task.d.ts",
-			"import": "./dist/task.js",
-			"svelte": "./dist/task.js"
+			"svelte": "./dist/task.js",
+			"import": "./dist/task.js"
+		},
+		"./utils": {
+			"types": "./dist/utils.d.ts",
+			"svelte": "./dist/utils.js",
+			"import": "./dist/utils.js"
 		},
 		"./vite": {
 			"types": "./dist/vite.d.ts",


### PR DESCRIPTION
Add the `utils` export so that even if we don't get the treeshake from the main export people can still import from the `/task` sub export and only get that.