### PR TITLE
Fix dark mode get started button appearing with the wrong colors

### DIFF
--- a/apps/docs/src/components/Hero.astro
+++ b/apps/docs/src/components/Hero.astro
@@ -115,7 +115,7 @@ if (image) {
     }
 
 		.actions > :global(.primary) {
-        background: var(--sheepdog-primary);
+        background: var(--sheepdog-primary)!important;
 				text-transform: uppercase;
 				font-weight: 700;
 				border-radius: 1.25rem;


### PR DESCRIPTION
Minor fix, broke only in production for some reason.

Before:
<img width="418" alt="Screenshot 2024-10-18 at 12 42 52" src="https://github.com/user-attachments/assets/a7f8af72-43a7-447f-a23d-f482468c4509">

After:
<img width="424" alt="Screenshot 2024-10-18 at 12 43 16" src="https://github.com/user-attachments/assets/a7034b70-bdf1-4d69-b0a9-2a0b9785aacc">
