### PR TITLE
Fix logo size issue

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -32,7 +32,7 @@ export default defineConfig({
 					tag: 'link',
 					attrs: {
 						rel: 'shortcut icon',
-						href: '/logo-light.svg',
+						href: '/full-color.svg',
 						media: '(prefers-color-scheme: light)',
 					},
 				},
@@ -40,7 +40,7 @@ export default defineConfig({
 					tag: 'link',
 					attrs: {
 						rel: 'shortcut icon',
-						href: '/logo-dark.svg',
+						href: '/1c-plus.svg',
 						media: '(prefers-color-scheme: dark)',
 					},
 				},

--- a/apps/docs/src/components/Hero.astro
+++ b/apps/docs/src/components/Hero.astro
@@ -11,8 +11,6 @@ const { title = data.title, tagline, image, actions = [] } = data.hero || {};
 const imageAttrs = {
 	loading: 'eager' as const,
 	decoding: 'async' as const,
-	width: 400,
-	height: 400,
 	alt: image?.alt || '',
 };
 


### PR DESCRIPTION
This caused some layout shift due to the logos not actually being square, but 100 x 90.

If we remove the width/height definition Astro will automatically infer the correct aspect ratio from the files.