### PR TITLE
feat: add support for `@sheepdog-transform` comment

### DIFF
--- a/packages/svelte/.gitignore
+++ b/packages/svelte/.gitignore
@@ -10,3 +10,4 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 coverage
+src/lib/tests/expected-transforms/**/_actual.js

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -55,12 +55,14 @@
 		"test:unit:ui": "vitest --ui"
 	},
 	"dependencies": {
+		"@types/node": "^22.7.6",
 		"acorn": "^8.11.3",
 		"esrap": "^1.2.2",
 		"zimmerframe": "^1.1.2"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.44.0",
+		"@sheepdog/svelte": "link:.",
 		"@sveltejs/adapter-auto": "^3.2.0",
 		"@sveltejs/kit": "^2.5.8",
 		"@sveltejs/package": "^2.3.1",
@@ -90,8 +92,7 @@
 		"typescript": "^5.4.5",
 		"typescript-eslint": "^8.0.0",
 		"vite": "^5.2.11",
-		"vitest": "^2.1.2",
-		"@sheepdog/svelte": "link:."
+		"vitest": "^2.1.2"
 	},
 	"peerDependencies": {
 		"svelte": "^4.0.0 || ^5.0.0 || ^5.0.0-next.1"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -55,7 +55,6 @@
 		"test:unit:ui": "vitest --ui"
 	},
 	"dependencies": {
-		"@types/node": "^22.7.6",
 		"acorn": "^8.11.3",
 		"esrap": "^1.2.2",
 		"zimmerframe": "^1.1.2"
@@ -72,6 +71,7 @@
 		"@types/eslint": "9.6.1",
 		"@types/eslint-config-prettier": "^6.11.3",
 		"@types/eslint__js": "^8.42.3",
+		"@types/node": "^22.7.6",
 		"@vitest/coverage-v8": "^2.0.0",
 		"@vitest/ui": "^2.0.0",
 		"eslint": "^9.2.0",

--- a/packages/svelte/src/lib/tests/expected-transforms/add-yield-after-await-assignment/transform.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/add-yield-after-await-assignment/transform.js
@@ -1,11 +1,22 @@
 import { task } from "@sheepdog/svelte";
 
+/**
+ * @param {number} val 
+ */
 function fn(val) {
 	return val;
 }
 
+/**
+ * @type {Record<string,()=>void>}
+ */
 const fns = {};
 
+/**
+ * 
+ * @param {TemplateStringsArray} quasi 
+ * @param {string} strings 
+ */
 function str(quasi, strings) {}
 
 task(async function* () {

--- a/packages/svelte/src/lib/tests/expected-transforms/annotated-function/code.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/annotated-function/code.js
@@ -1,0 +1,799 @@
+/**
+ * @param {number} val
+ */
+function fn(val) {
+	return val;
+}
+
+/**
+ * @type {Record<string,()=>void>}
+ */
+const fns = {};
+
+/**
+ *
+ * @param {TemplateStringsArray} quasi
+ * @param {string} strings
+ */
+function str(quasi, strings) {}
+
+/**
+ * @sheepdog-transform
+ */
+export async function task_fn() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+// @sheepdog-transform
+export async function task_fn_singleline() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+export async function task_fn_comment_top() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+// with comment on top
+// @sheepdog-transform
+export async function task_fn_singleline_comment_top() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform with comment after
+ */
+export async function task_fn_comment_after() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+// @sheepdog-transform with comment after
+export async function task_fn_singleline_comment_after() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform
+ */
+async function task_fn_no_export() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+// @sheepdog-transform
+async function task_fn_singleline_no_export() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+async function task_fn_comment_top_no_export() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+// with comment on top
+// @sheepdog-transform
+async function task_fn_singleline_comment_top_no_export() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform with comment after
+ */
+async function task_fn_comment_after_no_export() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+// @sheepdog-transform with comment after
+async function task_fn_singleline_comment_after_no_export() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform
+ */
+export const task_const = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+// @sheepdog-transform
+export const task_const_singleline = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+export const task_const_comment_top = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+// with comment on top
+// @sheepdog-transform
+export const task_const_singleline_comment_top = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+/**
+ * @sheepdog-transform with comment after
+ */
+export const task_const_comment_after = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+// @sheepdog-transform with comment after
+export const task_const_singleline_comment_after = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+/**
+ * @sheepdog-transform
+ */
+const task_const_no_export = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+// @sheepdog-transform
+const task_const_singleline_no_export = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+const task_const_comment_top_no_export = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+// with comment on top
+// @sheepdog-transform
+const task_const_singleline_comment_top_no_export = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+/**
+ * @sheepdog-transform with comment after
+ */
+const task_const_comment_after_no_export = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+// @sheepdog-transform with comment after
+const task_const_singleline_comment_after_no_export = async () => {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+};
+
+async function with_no_comment() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+	assignment = await Promise.resolve();
+	const array = [await Promise.resolve()];
+	const sum = (await Promise.resolve(1)) + 2;
+	const sum2 = 2 + (await Promise.resolve(1));
+	fns[await Promise.resolve(0)]();
+	const [array_destructure = await Promise.resolve()] = [undefined];
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = (await Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+	const logical1 = (await Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (await Promise.resolve(null));
+	const logical3 = null || (await Promise.resolve(null));
+	const logical4 = (await Promise.resolve(null)) || null;
+	const logical5 = (await Promise.resolve(null)) && null;
+	const logical6 = true && (await Promise.resolve(null));
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+	const object_expression2 = { awaited: { nested: await Promise.resolve(2) } };
+	const object_expression3 = { awaited: { nested: [await Promise.resolve(2)] } };
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !(await Promise.resolve(true));
+}

--- a/packages/svelte/src/lib/tests/expected-transforms/annotated-function/transform.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/annotated-function/transform.js
@@ -1,0 +1,1199 @@
+/**
+ * @param {number} val
+ */
+function fn(val) {
+	return val;
+}
+
+/**
+ * @type {Record<string,()=>void>}
+ */
+const fns = {};
+
+/**
+ *
+ * @param {TemplateStringsArray} quasi
+ * @param {string} strings
+ */
+function str(quasi, strings) {}
+
+/**
+ * @sheepdog-transform
+ */
+export async function* task_fn() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+// @sheepdog-transform
+export async function* task_fn_singleline() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+export async function* task_fn_comment_top() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+// with comment on top
+// @sheepdog-transform
+export async function* task_fn_singleline_comment_top() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform with comment after
+ */
+export async function* task_fn_comment_after() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+// @sheepdog-transform with comment after
+export async function* task_fn_singleline_comment_after() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform
+ */
+async function* task_fn_no_export() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+// @sheepdog-transform
+async function* task_fn_singleline_no_export() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+async function* task_fn_comment_top_no_export() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+// with comment on top
+// @sheepdog-transform
+async function* task_fn_singleline_comment_top_no_export() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform with comment after
+ */
+async function* task_fn_comment_after_no_export() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+// @sheepdog-transform with comment after
+async function* task_fn_singleline_comment_after_no_export() {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+}
+
+/**
+ * @sheepdog-transform
+ */
+export const task_const = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+// @sheepdog-transform
+export const task_const_singleline = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+export const task_const_comment_top = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+// with comment on top
+// @sheepdog-transform
+export const task_const_singleline_comment_top = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+/**
+ * @sheepdog-transform with comment after
+ */
+export const task_const_comment_after = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+// @sheepdog-transform with comment after
+export const task_const_singleline_comment_after = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+/**
+ * @sheepdog-transform
+ */
+const task_const_no_export = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+// @sheepdog-transform
+const task_const_singleline_no_export = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+/**
+ * With comment on top
+ * @sheepdog-transform
+ */
+const task_const_comment_top_no_export = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+// with comment on top
+// @sheepdog-transform
+const task_const_singleline_comment_top_no_export = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+/**
+ * @sheepdog-transform with comment after
+ */
+const task_const_comment_after_no_export = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+// @sheepdog-transform with comment after
+const task_const_singleline_comment_after_no_export = async function* () {
+	const assign = yield Promise.resolve();
+	let assignment = null;
+
+	assignment = yield Promise.resolve();
+
+	const array = [yield Promise.resolve()];
+	const sum = (yield Promise.resolve(1)) + 2;
+	const sum2 = 2 + (yield Promise.resolve(1));
+
+	fns[yield Promise.resolve(0)]();
+
+	const [
+		array_destructure = yield Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(yield Promise.resolve(2));
+	const conditional1 = (yield Promise.resolve(true)) ? 1 : 2;
+	const conditional2 = true ? yield Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : yield Promise.resolve(2);
+	const member = { property: null };
+
+	member[yield Promise.resolve('property')] = yield Promise.resolve(null);
+
+	const logical1 = (yield Promise.resolve(null)) ?? 3;
+	const logical2 = null ?? (yield Promise.resolve(null));
+	const logical3 = null || (yield Promise.resolve(null));
+	const logical4 = (yield Promise.resolve(null)) || null;
+	const logical5 = (yield Promise.resolve(null)) && null;
+	const logical6 = true && (yield Promise.resolve(null));
+	const object_expression1 = { awaited: yield Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: yield Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [yield Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${yield Promise.resolve('')}`;
+	const template_literal = `something ${yield Promise.resolve('')}`;
+	const unary = !(yield Promise.resolve(true));
+};
+
+async function with_no_comment() {
+	const assign = await Promise.resolve();
+	let assignment = null;
+
+	assignment = await Promise.resolve();
+
+	const array = [await Promise.resolve()];
+	const sum = await Promise.resolve(1) + 2;
+	const sum2 = 2 + await Promise.resolve(1);
+
+	fns[await Promise.resolve(0)]();
+
+	const [
+		array_destructure = await Promise.resolve()
+	] = [undefined];
+
+	const function_call = fn(await Promise.resolve(2));
+	const conditional1 = await Promise.resolve(true) ? 1 : 2;
+	const conditional2 = true ? await Promise.resolve(1) : 2;
+	const conditional3 = false ? 1 : await Promise.resolve(2);
+	const member = { property: null };
+
+	member[await Promise.resolve('property')] = await Promise.resolve(null);
+
+	const logical1 = await Promise.resolve(null) ?? 3;
+	const logical2 = null ?? await Promise.resolve(null);
+	const logical3 = null || await Promise.resolve(null);
+	const logical4 = await Promise.resolve(null) || null;
+	const logical5 = await Promise.resolve(null) && null;
+	const logical6 = true && await Promise.resolve(null);
+	const object_expression1 = { awaited: await Promise.resolve(2) };
+
+	const object_expression2 = {
+		awaited: { nested: await Promise.resolve(2) }
+	};
+
+	const object_expression3 = {
+		awaited: { nested: [await Promise.resolve(2)] }
+	};
+
+	const tagged_template = str`something ${await Promise.resolve('')}`;
+	const template_literal = `something ${await Promise.resolve('')}`;
+	const unary = !await Promise.resolve(true);
+}

--- a/packages/svelte/src/lib/tests/expected-transforms/statements-in-blocks/transform.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/statements-in-blocks/transform.js
@@ -82,6 +82,7 @@ task(async function* () {
 		console.log(yield Promise.resolve());
 	} else console.log(yield Promise.resolve());
 
+	// nested test
 	for (const x of yield Promise.resolve([])) {
 		console.log(yield Promise.resolve("for of"));
 

--- a/packages/svelte/src/lib/tests/expected-transforms/task-aliased-plus-task-function/transform.js
+++ b/packages/svelte/src/lib/tests/expected-transforms/task-aliased-plus-task-function/transform.js
@@ -1,5 +1,9 @@
 import { task as other_name } from "@sheepdog/svelte";
 
+/**
+ * 
+ * @param {()=>void} fn 
+ */
 function task(fn) {
 	fn();
 }

--- a/packages/svelte/src/lib/tests/vite.test.ts
+++ b/packages/svelte/src/lib/tests/vite.test.ts
@@ -1,10 +1,11 @@
 import { asyncTransform } from '../vite';
 import { describe, it, expect } from 'vitest';
+import { writeFile } from 'fs/promises';
 
 const plugin = asyncTransform();
 
 const expected_entries = Object.entries(
-	import.meta.glob('./expected-transforms/**/*.js', { as: 'raw', eager: true }),
+	import.meta.glob('./expected-transforms/**/(code|transform).js', { as: 'raw', eager: true }),
 );
 const expected = new Map<string, { code: string; transform?: string }>();
 
@@ -26,6 +27,10 @@ describe('sheepdog transform', () => {
 	it.each([...expected.entries()])('%s', async (id, { code, transform }) => {
 		// @ts-expect-error we don't have the correct `this` here but we are not using it
 		const actual_transform = await plugin.transform(code, 'myfile.js');
+		if (actual_transform) {
+			// write the actual transform to file for better debugging
+			writeFile(`./src/lib/tests/expected-transforms/${id}/_actual.js`, actual_transform.code);
+		}
 		expect(actual_transform?.code).toBe(transform);
 	});
 });

--- a/packages/svelte/src/lib/vite.ts
+++ b/packages/svelte/src/lib/vite.ts
@@ -43,8 +43,7 @@ type Nodes = (
 
 /**
  * Acorn doesn't add comments to the AST by itself. This factory returns the capabilities
- * to add them after the fact. They are needed in order to support `svelte-ignore` comments
- * in JS code and so that `prettier-plugin-svelte` doesn't remove all comments when formatting.
+ * to add them after the fact.
  *
  * Stolen from the svelte codebase with love 🧡
  */

--- a/packages/svelte/src/lib/vite.ts
+++ b/packages/svelte/src/lib/vite.ts
@@ -3,32 +3,161 @@ import type {
 	AwaitExpression,
 	BlockStatement,
 	CallExpression,
+	Comment,
+	FunctionDeclaration,
 	FunctionExpression,
 	ImportDeclaration,
+	Node,
+	VariableDeclaration,
+	ExportDefaultDeclaration,
+	ExportNamedDeclaration,
 } from 'acorn';
 import { parse } from 'acorn';
 import { print } from 'esrap';
 import type { Plugin } from 'vite';
-import { walk } from 'zimmerframe';
+import { walk, type Context } from 'zimmerframe';
 
-type Nodes =
+type CommentWithLocation = Comment & {
+	start: number;
+	end: number;
+};
+
+type CommentsExtend = {
+	leadingComments?: CommentWithLocation[];
+	trailingComments?: CommentWithLocation[];
+};
+
+type Nodes = (
 	| ImportDeclaration
 	| FunctionExpression
 	| ArrowFunctionExpression
 	| CallExpression
 	| BlockStatement
-	| AwaitExpression;
+	| AwaitExpression
+	| FunctionDeclaration
+	| VariableDeclaration
+	| ExportDefaultDeclaration
+	| ExportNamedDeclaration
+) &
+	CommentsExtend;
+
+/**
+ * Acorn doesn't add comments to the AST by itself. This factory returns the capabilities
+ * to add them after the fact. They are needed in order to support `svelte-ignore` comments
+ * in JS code and so that `prettier-plugin-svelte` doesn't remove all comments when formatting.
+ *
+ * Stolen from the svelte codebase with love 🧡
+ */
+function get_comment_handlers(source: string) {
+	const comments: CommentWithLocation[] = [];
+
+	return {
+		onComment: (block: boolean, value: string, start: number, end: number) => {
+			if (block && /\n/.test(value)) {
+				let a = start;
+				while (a > 0 && source[a - 1] !== '\n') a -= 1;
+
+				let b = a;
+				while (/[ \t]/.test(source[b])) b += 1;
+
+				const indentation = source.slice(a, b);
+				value = value.replace(new RegExp(`^${indentation}`, 'gm'), '');
+			}
+
+			comments.push({ type: block ? 'Block' : 'Line', value, start, end });
+		},
+
+		add_comments(ast: Node & CommentsExtend) {
+			if (comments.length === 0) return;
+
+			walk(ast, null, {
+				_(node, { next, path }) {
+					let comment;
+
+					while (comments[0] && comments[0].start < node.start) {
+						comment = comments.shift() as CommentWithLocation;
+						(node.leadingComments ||= []).push(comment);
+					}
+
+					next();
+
+					if (comments[0]) {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const parent: any = path.at(-1);
+
+						if (parent === undefined || node.end !== parent.end) {
+							const slice = source.slice(node.end, comments[0].start);
+							const is_last_in_body =
+								((parent?.type === 'BlockStatement' || parent?.type === 'Program') &&
+									parent.body.indexOf(node) === parent.body.length - 1) ||
+								(parent?.type === 'ArrayExpression' &&
+									parent.elements.indexOf(node) === parent.elements.length - 1) ||
+								(parent?.type === 'ObjectExpression' &&
+									parent.properties.indexOf(node) === parent.properties.length - 1);
+
+							if (is_last_in_body) {
+								while (comments.length) {
+									const comment = comments[0];
+									if (parent && comment.start >= parent.end) break;
+
+									(node.trailingComments ||= []).push(comment);
+									comments.shift();
+								}
+							} else if (node.end <= comments[0].start && /^[,) \t]*$/.test(slice)) {
+								node.trailingComments = [comments.shift() as CommentWithLocation];
+							}
+						}
+					}
+				},
+			});
+
+			// Special case: Trailing comments after the root node (which can only happen for expression tags or for Program nodes).
+			// Adding them ensures that we can later detect the end of the expression tag correctly.
+			if (comments.length > 0 && (comments[0].start >= ast.end || ast.type === 'Program')) {
+				(ast.trailingComments ||= []).push(...comments.splice(0));
+			}
+		},
+	};
+}
+
+function check_for_transform_comment(
+	node: (FunctionDeclaration | VariableDeclaration) & CommentsExtend,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	{ path }: Context<Nodes, any>,
+) {
+	const parent = path[path.length - 1];
+	let to_check_for_comments: CommentsExtend = node;
+	if (parent.type === 'ExportDefaultDeclaration' || parent.type === 'ExportNamedDeclaration') {
+		to_check_for_comments = parent;
+	}
+	if (
+		to_check_for_comments.leadingComments?.some((comment) =>
+			comment.value
+				.split('\n')
+				.some((line) =>
+					line.replaceAll('*', '').toLowerCase().trim().startsWith('@sheepdog-transform'),
+				),
+		)
+	) {
+		return true;
+	}
+	return false;
+}
 
 export function asyncTransform() {
 	return {
 		name: 'sheepdog-async-transform',
 		async transform(code, id) {
 			try {
+				const { onComment, add_comments } = get_comment_handlers(code);
 				const ast = parse(code, {
 					ecmaVersion: 'latest',
 					locations: true,
 					sourceType: 'module',
+					onComment,
 				});
+				add_comments(ast);
+
 				let fn_name: string;
 				// let's walk once to find the name (we were using a promise before but that's just messy)
 				walk(
@@ -62,6 +191,40 @@ export function asyncTransform() {
 							if (state.transform) {
 								next();
 								node.type = 'YieldExpression' as never;
+							}
+						},
+						VariableDeclaration(node, context) {
+							let local_changed = false;
+							if (check_for_transform_comment(node, context)) {
+								for (const declaration of node.declarations) {
+									if (
+										(declaration.init?.type === 'ArrowFunctionExpression' ||
+											declaration.init?.type === 'FunctionExpression') &&
+										declaration.init.async
+									) {
+										const to_change = declaration.init as unknown as FunctionExpression;
+										to_change.type = 'FunctionExpression';
+										to_change.generator = true;
+										context.next({ ...context.state, transform: true });
+										changed = true;
+										local_changed = true;
+									}
+								}
+							}
+							if (!local_changed) {
+								context.next();
+							}
+						},
+						FunctionDeclaration(node, context) {
+							let local_changed = false;
+							if (check_for_transform_comment(node, context) && node.async) {
+								node.generator = true;
+								context.next({ ...context.state, transform: true });
+								local_changed = true;
+								changed = true;
+							}
+							if (!local_changed) {
+								context.next();
 							}
 						},
 						CallExpression(node, { state, next }) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,13 +45,13 @@ importers:
         version: 0.9.4(prettier@3.3.3)(typescript@5.6.3)
       '@astrojs/netlify':
         specifier: ^5.4.0
-        version: 5.5.4(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))(encoding@0.1.13)
+        version: 5.5.4(@types/node@22.7.6)(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))(encoding@0.1.13)
       '@astrojs/starlight':
         specifier: ^0.28.0
-        version: 0.28.3(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))
+        version: 0.28.3(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))
       '@astrojs/svelte':
         specifier: ^5.4.0
-        version: 5.7.2(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))(svelte@4.2.19)(typescript@5.6.3)(vite@5.4.9)
+        version: 5.7.2(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))(svelte@4.2.19)(typescript@5.6.3)(vite@5.4.9(@types/node@22.7.6))
       '@fontsource/calistoga':
         specifier: ^5.0.21
         version: 5.1.0
@@ -63,7 +63,7 @@ importers:
         version: link:../../packages/svelte
       astro:
         specifier: ^4.3.5
-        version: 4.16.1(rollup@4.24.0)(typescript@5.6.3)
+        version: 4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3)
       sharp:
         specifier: ^0.33.0
         version: 0.33.5
@@ -76,6 +76,9 @@ importers:
 
   packages/svelte:
     dependencies:
+      '@types/node':
+        specifier: ^22.7.6
+        version: 22.7.6
       acorn:
         specifier: ^8.11.3
         version: 8.13.0
@@ -94,22 +97,22 @@ importers:
         version: 'link:'
       '@sveltejs/adapter-auto':
         specifier: ^3.2.0
-        version: 3.2.5(@sveltejs/kit@2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9))(svelte@4.2.19)(vite@5.4.9))
+        version: 3.2.5(@sveltejs/kit@2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))
       '@sveltejs/kit':
         specifier: ^2.5.8
-        version: 2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9))(svelte@4.2.19)(vite@5.4.9)
+        version: 2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))
       '@sveltejs/package':
         specifier: ^2.3.1
         version: 2.3.5(svelte@4.2.19)(typescript@5.6.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
-        version: 3.1.2(svelte@4.2.19)(vite@5.4.9)
+        version: 3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))
       '@testing-library/jest-dom':
         specifier: ^6.4.5
         version: 6.6.2
       '@testing-library/svelte':
         specifier: ^5.1.0
-        version: 5.2.3(svelte@4.2.19)(vite@5.4.9)(vitest@2.1.3)
+        version: 5.2.3(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))(vitest@2.1.3)
       '@types/eslint':
         specifier: 9.6.1
         version: 9.6.1
@@ -178,10 +181,10 @@ importers:
         version: 8.10.0(eslint@9.12.0)(typescript@5.6.3)
       vite:
         specifier: ^5.2.11
-        version: 5.4.9
+        version: 5.4.9(@types/node@22.7.6)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.3(@vitest/ui@2.1.3)(happy-dom@15.7.4)
+        version: 2.1.3(@types/node@22.7.6)(@vitest/ui@2.1.3)(happy-dom@15.7.4)
 
 packages:
 
@@ -1362,6 +1365,9 @@ packages:
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
+  '@types/node@22.7.6':
+    resolution: {integrity: sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==}
 
   '@types/rimraf@3.0.2':
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
@@ -4500,6 +4506,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -5022,12 +5031,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@3.1.8(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))':
+  '@astrojs/mdx@3.1.8(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))':
     dependencies:
       '@astrojs/markdown-remark': 5.3.0
       '@mdx-js/mdx': 3.0.1
       acorn: 8.13.0
-      astro: 4.16.1(rollup@4.24.0)(typescript@5.6.3)
+      astro: 4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3)
       es-module-lexer: 1.5.4
       estree-util-visit: 2.0.0
       gray-matter: 4.0.3
@@ -5042,15 +5051,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/netlify@5.5.4(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))(encoding@0.1.13)':
+  '@astrojs/netlify@5.5.4(@types/node@22.7.6)(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))(encoding@0.1.13)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.1
       '@astrojs/underscore-redirects': 0.3.4
       '@netlify/functions': 2.8.2
       '@vercel/nft': 0.27.4(encoding@0.1.13)
-      astro: 4.16.1(rollup@4.24.0)(typescript@5.6.3)
+      astro: 4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3)
       esbuild: 0.21.5
-      vite: 5.4.9
+      vite: 5.4.9(@types/node@22.7.6)
     transitivePeerDependencies:
       - '@types/node'
       - encoding
@@ -5073,15 +5082,15 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight@0.28.3(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))':
+  '@astrojs/starlight@0.28.3(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))':
     dependencies:
-      '@astrojs/mdx': 3.1.8(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))
+      '@astrojs/mdx': 3.1.8(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))
       '@astrojs/sitemap': 3.2.0
       '@pagefind/default-ui': 1.1.1
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      astro: 4.16.1(rollup@4.24.0)(typescript@5.6.3)
-      astro-expressive-code: 0.35.6(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))
+      astro: 4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3)
+      astro-expressive-code: 0.35.6(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.2
@@ -5101,10 +5110,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/svelte@5.7.2(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3))(svelte@4.2.19)(typescript@5.6.3)(vite@5.4.9)':
+  '@astrojs/svelte@5.7.2(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3))(svelte@4.2.19)(typescript@5.6.3)(vite@5.4.9(@types/node@22.7.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.9)
-      astro: 4.16.1(rollup@4.24.0)(typescript@5.6.3)
+      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))
+      astro: 4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3)
       svelte: 4.2.19
       svelte2tsx: 0.7.21(svelte@4.2.19)(typescript@5.6.3)
       typescript: 5.6.3
@@ -6196,14 +6205,14 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@sveltejs/adapter-auto@3.2.5(@sveltejs/kit@2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9))(svelte@4.2.19)(vite@5.4.9))':
+  '@sveltejs/adapter-auto@3.2.5(@sveltejs/kit@2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))':
     dependencies:
-      '@sveltejs/kit': 2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9))(svelte@4.2.19)(vite@5.4.9)
+      '@sveltejs/kit': 2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9))(svelte@4.2.19)(vite@5.4.9)':
+  '@sveltejs/kit@2.7.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.9)
+      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -6217,7 +6226,7 @@ snapshots:
       sirv: 3.0.0
       svelte: 4.2.19
       tiny-glob: 0.2.9
-      vite: 5.4.9
+      vite: 5.4.9(@types/node@22.7.6)
 
   '@sveltejs/package@2.3.5(svelte@4.2.19)(typescript@5.6.3)':
     dependencies:
@@ -6230,26 +6239,26 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9))(svelte@4.2.19)(vite@5.4.9)':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.9)
+      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))
       debug: 4.3.7
       svelte: 4.2.19
-      vite: 5.4.9
+      vite: 5.4.9(@types/node@22.7.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9)':
+  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9))(svelte@4.2.19)(vite@5.4.9)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6)))(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
       svelte: 4.2.19
       svelte-hmr: 0.16.0(svelte@4.2.19)
-      vite: 5.4.9
-      vitefu: 0.2.5(vite@5.4.9)
+      vite: 5.4.9(@types/node@22.7.6)
+      vitefu: 0.2.5(vite@5.4.9(@types/node@22.7.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -6278,13 +6287,13 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/svelte@5.2.3(svelte@4.2.19)(vite@5.4.9)(vitest@2.1.3)':
+  '@testing-library/svelte@5.2.3(svelte@4.2.19)(vite@5.4.9(@types/node@22.7.6))(vitest@2.1.3)':
     dependencies:
       '@testing-library/dom': 10.4.0
       svelte: 4.2.19
     optionalDependencies:
-      vite: 5.4.9
-      vitest: 2.1.3(@vitest/ui@2.1.3)(happy-dom@15.7.4)
+      vite: 5.4.9(@types/node@22.7.6)
+      vitest: 2.1.3(@types/node@22.7.6)(@vitest/ui@2.1.3)(happy-dom@15.7.4)
 
   '@tootallnate/once@1.1.2': {}
 
@@ -6342,12 +6351,12 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.7.6
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 17.0.45
+      '@types/node': 22.7.6
 
   '@types/hast@3.0.4':
     dependencies:
@@ -6375,10 +6384,14 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
+  '@types/node@22.7.6':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/rimraf@3.0.2':
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 17.0.45
+      '@types/node': 22.7.6
 
   '@types/sax@1.2.7':
     dependencies:
@@ -6386,7 +6399,7 @@ snapshots:
 
   '@types/ssri@7.1.5':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.7.6
 
   '@types/unist@2.0.11': {}
 
@@ -6507,7 +6520,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.3(@vitest/ui@2.1.3)(happy-dom@15.7.4)
+      vitest: 2.1.3(@types/node@22.7.6)(@vitest/ui@2.1.3)(happy-dom@15.7.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -6518,13 +6531,13 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@22.7.6))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      vite: 5.4.9
+      vite: 5.4.9(@types/node@22.7.6)
 
   '@vitest/pretty-format@2.1.3':
     dependencies:
@@ -6554,7 +6567,7 @@ snapshots:
       sirv: 2.0.4
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.3(@vitest/ui@2.1.3)(happy-dom@15.7.4)
+      vitest: 2.1.3(@types/node@22.7.6)(@vitest/ui@2.1.3)(happy-dom@15.7.4)
 
   '@vitest/utils@2.1.3':
     dependencies:
@@ -6731,12 +6744,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.35.6(astro@4.16.1(rollup@4.24.0)(typescript@5.6.3)):
+  astro-expressive-code@0.35.6(astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3)):
     dependencies:
-      astro: 4.16.1(rollup@4.24.0)(typescript@5.6.3)
+      astro: 4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3)
       rehype-expressive-code: 0.35.6
 
-  astro@4.16.1(rollup@4.24.0)(typescript@5.6.3):
+  astro@4.16.1(@types/node@22.7.6)(rollup@4.24.0)(typescript@5.6.3):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.1
@@ -6792,8 +6805,8 @@ snapshots:
       tsconfck: 3.1.4(typescript@5.6.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 5.4.9
-      vitefu: 1.0.3(vite@5.4.9)
+      vite: 5.4.9(@types/node@22.7.6)
+      vitefu: 1.0.3(vite@5.4.9(@types/node@22.7.6))
       which-pm: 3.0.0
       xxhash-wasm: 1.0.2
       yargs-parser: 21.1.1
@@ -10126,6 +10139,8 @@ snapshots:
 
   typescript@5.6.3: {}
 
+  undici-types@6.19.8: {}
+
   unicorn-magic@0.1.0: {}
 
   unicorn-magic@0.3.0: {}
@@ -10244,12 +10259,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@2.1.3:
+  vite-node@2.1.3(@types/node@22.7.6):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.4.9
+      vite: 5.4.9(@types/node@22.7.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10261,26 +10276,27 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.9:
+  vite@5.4.9(@types/node@22.7.6):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
+      '@types/node': 22.7.6
       fsevents: 2.3.3
 
-  vitefu@0.2.5(vite@5.4.9):
+  vitefu@0.2.5(vite@5.4.9(@types/node@22.7.6)):
     optionalDependencies:
-      vite: 5.4.9
+      vite: 5.4.9(@types/node@22.7.6)
 
-  vitefu@1.0.3(vite@5.4.9):
+  vitefu@1.0.3(vite@5.4.9(@types/node@22.7.6)):
     optionalDependencies:
-      vite: 5.4.9
+      vite: 5.4.9(@types/node@22.7.6)
 
-  vitest@2.1.3(@vitest/ui@2.1.3)(happy-dom@15.7.4):
+  vitest@2.1.3(@types/node@22.7.6)(@vitest/ui@2.1.3)(happy-dom@15.7.4):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@22.7.6))
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -10295,10 +10311,11 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.9
-      vite-node: 2.1.3
+      vite: 5.4.9(@types/node@22.7.6)
+      vite-node: 2.1.3(@types/node@22.7.6)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 22.7.6
       '@vitest/ui': 2.1.3(vitest@2.1.3)
       happy-dom: 15.7.4
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,9 +76,6 @@ importers:
 
   packages/svelte:
     dependencies:
-      '@types/node':
-        specifier: ^22.7.6
-        version: 22.7.6
       acorn:
         specifier: ^8.11.3
         version: 8.13.0
@@ -122,6 +119,9 @@ importers:
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
+      '@types/node':
+        specifier: ^22.7.6
+        version: 22.7.6
       '@vitest/coverage-v8':
         specifier: ^2.0.0
         version: 2.1.3(vitest@2.1.3)


### PR DESCRIPTION
Just had an awesome idea on lunch and couldn't restrain myself from implementing it. With this change users will have the ability to annotate a function so that it can be converted by the async transform. This means that even if they don't want to write the task inline for some reason they can just do

```ts
/**
 * @sheepdog-transform
 */
export async function task_fn() {
    await Promise.resolve();
}
```

and the vite plugin will convert this into

```ts
/**
 * @sheepdog-transform
 */
export async function* task_fn() {
    yield Promise.resolve();
}
```

I had to change some test because now we are keeping comments but that's it. WDYT about this feature? If we are ok with it i'll add this to the documentation.