### PR TITLE
add wildcard redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
-from = "https://sheepdogjs.com/"
-to = "https://sheepdog.run/"
+from = "https://sheepdogjs.com/*"
+to = "https://sheepdog.run/:splat"
 status = 301
 force = true


### PR DESCRIPTION
This PR hopefully fixes all redirects from sheepdogjs.com to sheepdog.run based on the [netlify docs](https://docs.netlify.com/routing/redirects/redirect-options/#splats)