### PR TITLE
update release-plan

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
+      - master
+  pull_request_target: # This workflow has permissions on the repo, do NOT run code from PRs in this workflow. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     types:
       - labeled
+      - unlabeled
 
 concurrency:
   group: plan-release # only the latest one of these should ever be running
@@ -13,7 +15,7 @@ concurrency:
 
 jobs:
   check-plan:
-    name: 'Check Release Plan'
+    name: "Check Release Plan"
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check-release.outputs.command }}
@@ -28,19 +30,20 @@ jobs:
       - id: check-release
         run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
 
-  prepare_release_notes:
+  prepare-release-notes:
     name: Prepare Release Notes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: check-plan
     permissions:
       contents: write
+      issues: read
       pull-requests: write
     outputs:
       explanation: ${{ steps.explanation.outputs.text }}
     # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
     # only run on labeled event if the PR has already been merged
-    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
 
     steps:
       - uses: actions/checkout@v4
@@ -49,40 +52,35 @@ jobs:
         with:
           fetch-depth: 0
           ref: 'main'
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
-
-      - name: 'Generate Explanation and Prep Changelogs'
+      - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
           set +e
-
-          pnpm release-plan prepare 2> >(tee -a stderr.log >&2)
-
+          pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
 
           if [ $? -ne 0 ]; then
             echo 'text<<EOF' >> $GITHUB_OUTPUT
-            cat stderr.log >> $GITHUB_OUTPUT
+            cat release-plan-stderr.txt >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
           else
             echo 'text<<EOF' >> $GITHUB_OUTPUT
             jq .description .release-plan.json -r >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
+            rm release-plan-stderr.txt
           fi
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Fix linting'
-        run: pnpm format
+
       - uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "Prepare Release using 'release-plan'"
-          labels: 'internal'
+          labels: "internal"
           branch: release-preview
           title: Prepare Release
           body: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   check-plan:
-    name: 'Check Release Plan'
+    name: "Check Release Plan"
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check-release.outputs.command }}
@@ -34,29 +34,28 @@ jobs:
         run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
 
   publish:
-    name: 'NPM Publish'
+    name: "NPM Publish"
     runs-on: ubuntu-latest
     needs: check-plan
     if: needs.check-plan.outputs.command == 'release'
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
-
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: npm publish
-        run: pnpm release-plan publish
-
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+# Release Process
+
+Releases in this repo are mostly automated using [release-plan](https://github.com/embroider-build/release-plan/). Once you label all your PRs correctly (see below) you will have an automatically generated PR that updates your CHANGELOG.md file and a `.release-plan.json` that is used to prepare the release once the PR is merged.
+
+## Preparation
+
+Since the majority of the actual release process is automated, the remaining tasks before releasing are:
+
+- correctly labeling **all** pull requests that have been merged since the last release
+- updating pull request titles so they make sense to our users
+
+Some great information on why this is important can be found at [keepachangelog.com](https://keepachangelog.com/en/1.1.0/), but the overall
+guiding principle here is that changelogs are for humans, not machines.
+
+When reviewing merged PR's the labels to be used are:
+
+- breaking - Used when the PR is considered a breaking change.
+- enhancement - Used when the PR adds a new feature or enhancement.
+- bug - Used when the PR fixes a bug included in a previous release.
+- documentation - Used when the PR adds or updates documentation.
+- internal - Internal changes or things that don't fit in any other category.
+
+**Note:** `release-plan` requires that **all** PRs are labeled. If a PR doesn't fit in a category it's fine to label it as `internal`
+
+## Release
+
+Once the prep work is completed, the actual release is straight forward: you just need to merge the open [Plan Release](https://github.com/mainmatter/sheepdog/pulls?q=is%3Apr+is%3Aopen+%22Prepare+Release%22+in%3Atitle) PR

--- a/package.json
+++ b/package.json
@@ -1,37 +1,37 @@
 {
-	"name": "@sheepdog/root",
-	"repository": {
-		"type": "git",
-		"url": "git@github.com:mainmatter/sheepdog.git"
-	},
-	"version": "0.0.1",
-	"description": "monorepo for @sheepdog code and docs",
-	"private": true,
-	"scripts": {
-		"build:docs": "pnpm --dir packages/svelte build && pnpm --dir apps/docs build",
-		"dev:docs": "pnpm --dir apps/docs dev",
-		"dev": "pnpm --dir packages/svelte dev",
-		"test": "pnpm run --dir packages/svelte test",
-		"format": "pnpm -r format",
-		"lint": "pnpm -r lint"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
-	"type": "module",
-	"devDependencies": {
-		"@gravityci/cli": "^0.0.4",
-		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-svelte": "2.46.1",
-		"globals": "^15.2.0",
-		"prettier-plugin-svelte": "^3.2.3",
-		"release-plan": "^0.11.0",
-		"typescript": "^5.4.5",
-		"typescript-eslint": "^8.0.0"
-	},
-	"volta": {
-		"node": "22.12.0",
-		"pnpm": "9.14.4"
-	},
-	"packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
+  "name": "@sheepdog/root",
+  "version": "0.0.1",
+  "private": true,
+  "description": "monorepo for @sheepdog code and docs",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mainmatter/sheepdog.git"
+  },
+  "license": "ISC",
+  "author": "",
+  "type": "module",
+  "scripts": {
+    "build:docs": "pnpm --dir packages/svelte build && pnpm --dir apps/docs build",
+    "dev": "pnpm --dir packages/svelte dev",
+    "dev:docs": "pnpm --dir apps/docs dev",
+    "format": "pnpm -r format",
+    "lint": "pnpm -r lint",
+    "test": "pnpm run --dir packages/svelte test"
+  },
+  "devDependencies": {
+    "@gravityci/cli": "^0.0.4",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-svelte": "2.46.1",
+    "globals": "^15.2.0",
+    "prettier-plugin-svelte": "^3.2.3",
+    "release-plan": "^0.11.0",
+    "typescript": "^5.4.5",
+    "typescript-eslint": "^8.0.0"
+  },
+  "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab",
+  "volta": {
+    "node": "22.12.0",
+    "pnpm": "9.14.4"
+  }
 }


### PR DESCRIPTION
This just runs `npm init release-plan-setup@latest` to get the latest setup for release-plan 👍 This fixes the issue where adding a label to a PR after it has been merged doesn't update the release PR

Added benefit: you will now get provenance on the released package 😂 