### PR TITLE
Improve error handling of the async transform

### DIFF
--- a/packages/core/vite.ts
+++ b/packages/core/vite.ts
@@ -5,6 +5,7 @@ import type {
 	CallExpression,
 	FunctionExpression,
 	ImportDeclaration,
+	Program,
 } from 'acorn';
 import type { Plugin } from 'vite';
 
@@ -25,11 +26,16 @@ export async function asyncTransform(): Promise<Plugin> {
 		name: 'sheepdog-async-transform',
 		async transform(code, id) {
 			try {
-				const ast = parse(code, {
-					ecmaVersion: 'latest',
-					locations: true,
-					sourceType: 'module',
-				});
+				let ast: Program;
+				try {
+					ast = parse(code, {
+						ecmaVersion: 'latest',
+						locations: true,
+						sourceType: 'module',
+					});
+				} catch {
+					return;
+				}
 				let task_fn_name: string;
 				const transform_fn_names = new Set<string>();
 				// let's walk once to find the name (we were using a promise before but that's just messy)


### PR DESCRIPTION
This issue that was brought up in #240 was merely Acorn trying to parse files that it could not parse - in this instance, it was a CSS file, but this could be the case for any type of file that is imported (image, JSON, etc.).

This PR simply wraps the `parse` call in a try-catch essentially ignore any attempts to parse non-parseable files while still outputting errors from the transform itself

Closes #240 