### PR TITLE
add bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,8 @@ body:
       description: Select the severity of this issue
       options:
         - annoyance
+        - serious but i have a workaround
+        - blocking me on a specific feature
         - blocking all usage of Sheepdog
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: "\U0001F41E Bug report"
+description: Report an issue with Sheepdog
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo or REPL that can reproduce the problem you ran into. If a report is provided without an easy way to reproduce the bug, it's likely we will not be able to help.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Select the severity of this issue
+      options:
+        - annoyance
+        - blocking all usage of Sheepdog
+    validations:
+      required: true
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package name
+      description: Select the Sheepdog package
+      options:
+        - core
+        - svelte
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds the initial bug report template. I have purposefully left users able to create an issue without a template to give more flexibility, but if it becomes an issue we can restrict it

Part of #244 