### PR TITLE
Config renovate to create separate group for docs app updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,15 @@
 			}
 		},
 		{
+			"extends": ["group:allNonMajor"],
+			"schedule": ["before 7am every friday"],
+			"lockFileMaintenance": {
+				"enabled": true
+			},
+			"matchFileNames": ["apps/docs/**"],
+			"groupName": "Docs app (non-major)"
+		},
+		{
 			"matchUpdateTypes": ["patch", "pin"],
 			"matchCurrentVersion": "!/^0/"
 		}


### PR DESCRIPTION
Not _quite_ sure if this will do what we need, so if anyone knows.. let me know before we merge.

The intention is:
- Group all non majors as before
- Group all non majors of the `apps/docs` package in a separate PR