### PR TITLE
fix: don't call the function if the task has been canceled before starting

### DIFF
--- a/apps/docs/src/content/docs/reference/restart.mdx
+++ b/apps/docs/src/content/docs/reference/restart.mdx
@@ -49,6 +49,12 @@ To specify a task as restartable, you can either use the dot notation or the opt
 
 </Tabs>
 
+<Aside type="caution">
+	If you invoke `perform` multiple times in the same microtask, only the last instance will actually
+	run because by the time the function is invoked the previous invocations would've been already
+	canceled.
+</Aside>
+
 ### Max concurrency
 
 This is how you can specify the maximum number of concurrent instances. The default is 1, here we're

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,6 +151,9 @@ export function createTask<TArgs = unknown, TReturn = unknown, TModifier = objec
 			handler(
 				() => {
 					queueMicrotask(async () => {
+						if (abort_controller.signal.aborted) {
+							return;
+						}
 						adapter.onInstanceStart(instance_id);
 						try {
 							const gen_or_value = await gen_or_fun(args[0]!, {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,97 +1,97 @@
 {
-  "name": "@sheepdog/svelte",
-  "version": "0.12.2",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mainmatter/sheepdog.git"
-  },
-  "main": "./dist/index.js",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js",
-      "import": "./dist/index.js"
-    },
-    "./task": {
-      "types": "./dist/task.d.ts",
-      "svelte": "./dist/task.js",
-      "import": "./dist/task.js"
-    },
-    "./utils": {
-      "types": "./dist/utils.d.ts",
-      "svelte": "./dist/utils.js",
-      "import": "./dist/utils.js"
-    },
-    "./vite": {
-      "types": "./dist/vite.d.ts",
-      "import": "./dist/vite.js"
-    }
-  },
-  "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "!dist/**/*.test.*",
-    "!dist/**/*.spec.*"
-  ],
-  "scripts": {
-    "build": "vite build && pnpm package",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "dev": "vite dev",
-    "format": "eslint . --fix && prettier --write .",
-    "lint": "prettier --check . && eslint .",
-    "package": "svelte-kit sync && svelte-package && publint",
-    "prepare": "pnpm package",
-    "prepublishOnly": "pnpm package",
-    "preview": "vite preview",
-    "test": "pnpm run test:unit && pnpm run test:treeshake",
-    "test:integration": "playwright test",
-    "test:unit": "vitest",
-    "test:treeshake": "pnpm package && vitest --config treeshake.vite.config.ts",
-    "test:unit:ui": "vitest --ui"
-  },
-  "dependencies": {
-    "@sheepdog/core": "workspace:*"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.44.0",
-    "@sveltejs/adapter-auto": "^4.0.0",
-    "@sveltejs/kit": "^2.5.8",
-    "@sveltejs/package": "^2.3.1",
-    "@sveltejs/vite-plugin-svelte": "^5.0.1",
-    "@testing-library/jest-dom": "^6.4.5",
-    "@testing-library/svelte": "^5.1.0",
-    "@types/eslint": "9.6.1",
-    "@types/eslint-config-prettier": "^6.11.3",
-    "@types/eslint__js": "^8.42.3",
-    "@vitest/coverage-v8": "^3.0.0",
-    "@vitest/ui": "^3.0.0",
-    "eslint": "^9.2.0",
-    "eslint-config-prettier": "^10.0.0",
-    "eslint-plugin-playwright": "^2.0.0",
-    "eslint-plugin-svelte": "2.46.1",
-    "execa": "^9.4.0",
-    "fixturify-project": "^7.1.3",
-    "globals": "^15.2.0",
-    "happy-dom": "^17.0.0",
-    "prettier": "^3.2.5",
-    "prettier-plugin-svelte": "^3.2.3",
-    "publint": "^0.3.0",
-    "svelte": "^5.0.0",
-    "svelte-check": "^4.0.0",
-    "tslib": "^2.6.2",
-    "tsm": "^2.3.0",
-    "typescript": "^5.4.5",
-    "typescript-eslint": "^8.0.0",
-    "vite": "^6.0.0",
-    "vitest": "^3.0.5"
-  },
-  "peerDependencies": {
-    "svelte": "^4.0.0 || ^5.0.0 || ^5.0.0-next.1"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
+	"name": "@sheepdog/svelte",
+	"version": "0.12.2",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/mainmatter/sheepdog.git"
+	},
+	"main": "./dist/index.js",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js",
+			"import": "./dist/index.js"
+		},
+		"./task": {
+			"types": "./dist/task.d.ts",
+			"svelte": "./dist/task.js",
+			"import": "./dist/task.js"
+		},
+		"./utils": {
+			"types": "./dist/utils.d.ts",
+			"svelte": "./dist/utils.js",
+			"import": "./dist/utils.js"
+		},
+		"./vite": {
+			"types": "./dist/vite.d.ts",
+			"import": "./dist/vite.js"
+		}
+	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*"
+	],
+	"scripts": {
+		"build": "vite build && pnpm package",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"dev": "vite dev",
+		"format": "eslint . --fix && prettier --write .",
+		"lint": "prettier --check . && eslint .",
+		"package": "svelte-kit sync && svelte-package && publint",
+		"prepare": "pnpm package",
+		"prepublishOnly": "pnpm package",
+		"preview": "vite preview",
+		"test": "pnpm run test:unit && pnpm run test:treeshake",
+		"test:integration": "playwright test",
+		"test:unit": "vitest",
+		"test:treeshake": "pnpm package && vitest --config treeshake.vite.config.ts",
+		"test:unit:ui": "vitest --ui"
+	},
+	"dependencies": {
+		"@sheepdog/core": "workspace:*"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.44.0",
+		"@sveltejs/adapter-auto": "^4.0.0",
+		"@sveltejs/kit": "^2.5.8",
+		"@sveltejs/package": "^2.3.1",
+		"@sveltejs/vite-plugin-svelte": "^5.0.1",
+		"@testing-library/jest-dom": "^6.4.5",
+		"@testing-library/svelte": "^5.1.0",
+		"@types/eslint": "9.6.1",
+		"@types/eslint-config-prettier": "^6.11.3",
+		"@types/eslint__js": "^8.42.3",
+		"@vitest/coverage-v8": "^3.0.0",
+		"@vitest/ui": "^3.0.0",
+		"eslint": "^9.2.0",
+		"eslint-config-prettier": "^10.0.0",
+		"eslint-plugin-playwright": "^2.0.0",
+		"eslint-plugin-svelte": "2.46.1",
+		"execa": "^9.4.0",
+		"fixturify-project": "^7.1.3",
+		"globals": "^15.2.0",
+		"happy-dom": "^17.0.0",
+		"prettier": "^3.2.5",
+		"prettier-plugin-svelte": "^3.2.3",
+		"publint": "^0.3.0",
+		"svelte": "^5.0.0",
+		"svelte-check": "^4.0.0",
+		"tslib": "^2.6.2",
+		"tsm": "^2.3.0",
+		"typescript": "^5.4.5",
+		"typescript-eslint": "^8.0.0",
+		"vite": "^6.0.0",
+		"vitest": "^3.0.5"
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0 || ^5.0.0 || ^5.0.0-next.1"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
 }

--- a/packages/svelte/src/vitest-setup.ts
+++ b/packages/svelte/src/vitest-setup.ts
@@ -1,12 +1,4 @@
 import '@testing-library/jest-dom/vitest';
-import { afterEach, beforeEach, vi } from 'vitest';
-
-beforeEach(() => {
-	vi.useFakeTimers();
-});
-
-afterEach(() => {
-	vi.useRealTimers();
-});
+import { vi } from 'vitest';
 
 vi.stubGlobal('requestAnimationFrame', () => {});


### PR DESCRIPTION
Closes #272 

I had to update a bunch of tests because using fake timers were messing with the scheduling (some microtask were never called) so i resorted to only use fake timers when we need fine grained control over it.

With this change there's a slight change in behavior but tbf i think it's the right one...if you invoke multiple perform in the same microtask the function is never invoked even for `restart` for example. So something like this

```ts
const my_task = task.restart(()=>{});

my_task.perform();
my_task.perform();
my_task.perform();
```
would actually invoke the function once, the last time while something like this

```ts
const my_task = task.restart(()=>{});

my_task.perform();
await Promise.resolve();
my_task.perform();
await Promise.resolve();
my_task.perform();
```
would invoke it three times and cancel each new one.

I think it's more correct (even if this meant changing some tests to adapt to this behavior).

WDYT?