### PR TITLE
chore: allow for better treeshake in esbuild/rolldown

### DIFF
--- a/packages/svelte/src/lib/task.ts
+++ b/packages/svelte/src/lib/task.ts
@@ -27,176 +27,180 @@ export type TaskInstance<TReturn = undefined> = {
 	value?: TReturn;
 };
 
-function _task<TArgs = unknown, TReturn = undefined>(
-	gen_or_fun: TaskFunction<TArgs, TReturn>,
-	options?: TaskOptions,
-) {
-	const { subscribe, ...result } = writable({
-		isRunning: false,
-		last: undefined as undefined | TaskInstance<TReturn>,
-		lastCanceled: undefined as undefined | TaskInstance<TReturn>,
-		lastErrored: undefined as undefined | TaskInstance<TReturn>,
-		lastRunning: undefined as undefined | TaskInstance<TReturn>,
-		lastSuccessful: undefined as undefined | TaskInstance<TReturn>,
-		performCount: 0,
-	});
-
-	const updateResult = (instance: TaskInstance<TReturn>, new_instance: boolean = false) => {
-		return result.update((old) => {
-			if (new_instance) {
-				old.performCount++;
-			}
-			const { isSuccessful, isError, isCanceled, isRunning } = instance;
-			if (isCanceled) {
-				old.lastCanceled = instance;
-			}
-			if (isError) {
-				old.lastErrored = instance;
-			}
-			if (isSuccessful) {
-				old.lastSuccessful = instance;
-			}
-			if (isRunning) {
-				old.lastRunning = instance;
-			} else if (old.lastRunning === instance) {
-				old.lastRunning = undefined;
-			}
-			old.last = instance;
-			old.isRunning = [...instances.values()].some((val) => val.get().isRunning);
-			return old;
+const task = /*#__PURE__*/ (() => {
+	function _task<TArgs = unknown, TReturn = undefined>(
+		gen_or_fun: TaskFunction<TArgs, TReturn>,
+		options?: TaskOptions,
+	) {
+		const { subscribe, ...result } = writable({
+			isRunning: false,
+			last: undefined as undefined | TaskInstance<TReturn>,
+			lastCanceled: undefined as undefined | TaskInstance<TReturn>,
+			lastErrored: undefined as undefined | TaskInstance<TReturn>,
+			lastRunning: undefined as undefined | TaskInstance<TReturn>,
+			lastSuccessful: undefined as undefined | TaskInstance<TReturn>,
+			performCount: 0,
 		});
+
+		const updateResult = (instance: TaskInstance<TReturn>, new_instance: boolean = false) => {
+			return result.update((old) => {
+				if (new_instance) {
+					old.performCount++;
+				}
+				const { isSuccessful, isError, isCanceled, isRunning } = instance;
+				if (isCanceled) {
+					old.lastCanceled = instance;
+				}
+				if (isError) {
+					old.lastErrored = instance;
+				}
+				if (isSuccessful) {
+					old.lastSuccessful = instance;
+				}
+				if (isRunning) {
+					old.lastRunning = instance;
+				} else if (old.lastRunning === instance) {
+					old.lastRunning = undefined;
+				}
+				old.last = instance;
+				old.isRunning = [...instances.values()].some((val) => val.get().isRunning);
+				return old;
+			});
+		};
+
+		const instances = new Map<string, WritableWithGet<TaskInstance<TReturn>>>();
+
+		const actual_task = createTask<TArgs, TReturn, ReadableWithGet<TaskInstance<TReturn>>>(
+			{
+				onDestroy(fn) {
+					onDestroy(fn);
+				},
+				onError(instance_id, error) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						instance.update((instance) => {
+							instance.error = error;
+							instance.isError = true;
+							instance.isFinished = true;
+							instance.isRunning = false;
+							return instance;
+						});
+						// we delete after a microtask to avoid returnModifier
+						// not founding the instance in case of a syncronous
+						// cancellation (for example with drop)
+						queueMicrotask(() => {
+							instances.delete(instance_id);
+						});
+						updateResult(instance.get());
+					}
+				},
+				onInstanceCancel(instance_id) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						instance.update((instance) => {
+							instance.isCanceled = true;
+							instance.isFinished = true;
+							instance.isRunning = false;
+							return instance;
+						});
+						// we delete after a microtask to avoid returnModifier
+						// not founding the instance in case of a syncronous
+						// cancellation (for example with drop)
+						queueMicrotask(() => {
+							instances.delete(instance_id);
+						});
+						updateResult(instance.get());
+					}
+				},
+				onInstanceCreate(instance_id) {
+					const instance_value = {
+						hasStarted: false,
+						isCanceled: false,
+						isError: false,
+						isFinished: false,
+						isRunning: false,
+						isSuccessful: false,
+					};
+					const instance = writable_with_get(instance_value);
+					instances.set(instance_id, instance);
+					updateResult(instance_value);
+				},
+				onInstanceStart(instance_id) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						instance.update((instance) => {
+							instance.hasStarted = true;
+							instance.isRunning = true;
+							return instance;
+						});
+						updateResult(instance.get(), true);
+					}
+				},
+				onInstanceComplete(instance_id, last_result) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						instance.update((instance) => {
+							instance.isFinished = true;
+							instance.isRunning = false;
+							instance.isSuccessful = true;
+							instance.value = last_result;
+							return instance;
+						});
+						// we delete after a microtask to avoid returnModifier
+						// not founding the instance in case of a synchronous
+						// cancellation (for example with drop)
+						queueMicrotask(() => {
+							instances.delete(instance_id);
+						});
+						updateResult(instance.get());
+					}
+				},
+				returnModifier(instance_id, returned_value) {
+					const instance = instances.get(instance_id);
+					if (!instance)
+						throw new Error('Return modifier has been called before the instance was created');
+					return Object.assign(returned_value, {
+						subscribe: instance.subscribe,
+						get: instance.get,
+					});
+				},
+			},
+			gen_or_fun,
+			options,
+		);
+		return Object.assign(actual_task, {
+			subscribe,
+		});
+	}
+
+	type HandlersShorthands = {
+		[K in HandlerType]: <TArgs = undefined, TReturn = unknown>(
+			gen_or_fun: (
+				args: TArgs,
+				utils: SheepdogUtils,
+			) => Promise<TReturn> | AsyncGenerator<unknown, TReturn, unknown>,
+			options?: Parameters<HandlersMap[K]> extends [] ? object : Parameters<HandlersMap[K]>[0],
+		) => ReturnType<typeof task<TArgs, TReturn>>;
 	};
 
-	const instances = new Map<string, WritableWithGet<TaskInstance<TReturn>>>();
+	const task: typeof _task & HandlersShorthands = _task as typeof _task & HandlersShorthands;
 
-	const actual_task = createTask<TArgs, TReturn, ReadableWithGet<TaskInstance<TReturn>>>(
-		{
-			onDestroy(fn) {
-				onDestroy(fn);
-			},
-			onError(instance_id, error) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					instance.update((instance) => {
-						instance.error = error;
-						instance.isError = true;
-						instance.isFinished = true;
-						instance.isRunning = false;
-						return instance;
-					});
-					// we delete after a microtask to avoid returnModifier
-					// not founding the instance in case of a syncronous
-					// cancellation (for example with drop)
-					queueMicrotask(() => {
-						instances.delete(instance_id);
-					});
-					updateResult(instance.get());
-				}
-			},
-			onInstanceCancel(instance_id) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					instance.update((instance) => {
-						instance.isCanceled = true;
-						instance.isFinished = true;
-						instance.isRunning = false;
-						return instance;
-					});
-					// we delete after a microtask to avoid returnModifier
-					// not founding the instance in case of a syncronous
-					// cancellation (for example with drop)
-					queueMicrotask(() => {
-						instances.delete(instance_id);
-					});
-					updateResult(instance.get());
-				}
-			},
-			onInstanceCreate(instance_id) {
-				const instance_value = {
-					hasStarted: false,
-					isCanceled: false,
-					isError: false,
-					isFinished: false,
-					isRunning: false,
-					isSuccessful: false,
-				};
-				const instance = writable_with_get(instance_value);
-				instances.set(instance_id, instance);
-				updateResult(instance_value);
-			},
-			onInstanceStart(instance_id) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					instance.update((instance) => {
-						instance.hasStarted = true;
-						instance.isRunning = true;
-						return instance;
-					});
-					updateResult(instance.get(), true);
-				}
-			},
-			onInstanceComplete(instance_id, last_result) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					instance.update((instance) => {
-						instance.isFinished = true;
-						instance.isRunning = false;
-						instance.isSuccessful = true;
-						instance.value = last_result;
-						return instance;
-					});
-					// we delete after a microtask to avoid returnModifier
-					// not founding the instance in case of a synchronous
-					// cancellation (for example with drop)
-					queueMicrotask(() => {
-						instances.delete(instance_id);
-					});
-					updateResult(instance.get());
-				}
-			},
-			returnModifier(instance_id, returned_value) {
-				const instance = instances.get(instance_id);
-				if (!instance)
-					throw new Error('Return modifier has been called before the instance was created');
-				return Object.assign(returned_value, {
-					subscribe: instance.subscribe,
-					get: instance.get,
-				});
-			},
-		},
-		gen_or_fun,
-		options,
-	);
-	return Object.assign(actual_task, {
-		subscribe,
-	});
-}
-
-type HandlersShorthands = {
-	[K in HandlerType]: <TArgs = undefined, TReturn = unknown>(
-		gen_or_fun: (
-			args: TArgs,
-			utils: SheepdogUtils,
-		) => Promise<TReturn> | AsyncGenerator<unknown, TReturn, unknown>,
-		options?: Parameters<HandlersMap[K]> extends [] ? object : Parameters<HandlersMap[K]>[0],
-	) => ReturnType<typeof task<TArgs, TReturn>>;
-};
-
-const task: typeof _task & HandlersShorthands = _task as typeof _task & HandlersShorthands;
-
-function is_key(handler: string): handler is HandlerType {
-	return handler in handlers;
-}
-
-for (const handler in handlers) {
-	if (is_key(handler)) {
-		task[handler] = (gen_or_fun, options) => {
-			if (!is_key(handler)) {
-				throw new Error('Impossible');
-			}
-			return _task(gen_or_fun, { ...(options ?? {}), kind: handler });
-		};
+	function is_key(handler: string): handler is HandlerType {
+		return handler in handlers;
 	}
-}
+
+	for (const handler in handlers) {
+		if (is_key(handler)) {
+			task[handler] = (gen_or_fun, options) => {
+				if (!is_key(handler)) {
+					throw new Error('Impossible');
+				}
+				return _task(gen_or_fun, { ...(options ?? {}), kind: handler });
+			};
+		}
+	}
+
+	return task;
+})();
 
 export { task };

--- a/packages/vanilla/src/task.ts
+++ b/packages/vanilla/src/task.ts
@@ -51,195 +51,199 @@ function define_properties<TOn, TFrom>(on: TOn, from: TFrom): asserts on is TOn 
 	}
 }
 
-function _task<TArgs = unknown, TReturn = undefined>(
-	gen_or_fun: TaskFunction<TArgs, TReturn>,
-	options?: TaskOptions,
-) {
-	const event_target = new EventTarget();
+const task = /*#__PURE__*/ (() => {
+	function _task<TArgs = unknown, TReturn = undefined>(
+		gen_or_fun: TaskFunction<TArgs, TReturn>,
+		options?: TaskOptions,
+	) {
+		const event_target = new EventTarget();
 
-	const task_instance = {
-		isRunning: false,
-		last: undefined as undefined | TaskInstance<TReturn>,
-		lastCanceled: undefined as undefined | TaskInstance<TReturn>,
-		lastErrored: undefined as undefined | TaskInstance<TReturn>,
-		lastRunning: undefined as undefined | TaskInstance<TReturn>,
-		lastSuccessful: undefined as undefined | TaskInstance<TReturn>,
-		performCount: 0,
-		on(event: Events, cb: () => void, options?: AddEventListenerOptions) {
-			event_target.addEventListener(event, cb, options);
-			return () => {
-				event_target.removeEventListener(event, cb, options);
-			};
-		},
-		destroy() {},
+		const task_instance = {
+			isRunning: false,
+			last: undefined as undefined | TaskInstance<TReturn>,
+			lastCanceled: undefined as undefined | TaskInstance<TReturn>,
+			lastErrored: undefined as undefined | TaskInstance<TReturn>,
+			lastRunning: undefined as undefined | TaskInstance<TReturn>,
+			lastSuccessful: undefined as undefined | TaskInstance<TReturn>,
+			performCount: 0,
+			on(event: Events, cb: () => void, options?: AddEventListenerOptions) {
+				event_target.addEventListener(event, cb, options);
+				return () => {
+					event_target.removeEventListener(event, cb, options);
+				};
+			},
+			destroy() {},
+		};
+
+		function update_is_running() {
+			task_instance.isRunning = [...instances.values()].some((val) => val.is_running);
+		}
+
+		const instances = new Map<string, MappedInstance<TReturn>>();
+
+		const actual_task = createTask<TArgs, TReturn, TaskInstance<TReturn>>(
+			{
+				onDestroy(fn) {
+					task_instance.destroy = fn;
+				},
+				onError(instance_id, error) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						task_instance.lastErrored = instance.instance;
+						task_instance.lastRunning = undefined;
+						instance.instance.error = error;
+						instance.is_running = false;
+						update_is_running();
+						instance.event_target.dispatchEvent(new SheepdogInstanceEvent('error'));
+						instance.event_target.dispatchEvent(new SheepdogInstanceEvent('finish'));
+						// we delete after a microtask to avoid returnModifier
+						// not finding the instance in case of a synchronous
+						// cancellation (for example with drop)
+						queueMicrotask(() => {
+							instances.delete(instance_id);
+							for (const off of instance.offs) {
+								off();
+							}
+						});
+					}
+					event_target.dispatchEvent(new SheepdogEvent('instance-error'));
+					event_target.dispatchEvent(new SheepdogEvent('instance-finish'));
+					if (![...instances.values()].some((instance) => instance.is_running)) {
+						event_target.dispatchEvent(new SheepdogEvent('finish'));
+					}
+				},
+				onInstanceCancel(instance_id) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						task_instance.lastCanceled = instance.instance;
+						task_instance.lastRunning = undefined;
+						instance.is_running = false;
+						update_is_running();
+						instance.event_target.dispatchEvent(new SheepdogInstanceEvent('cancel'));
+						instance.event_target.dispatchEvent(new SheepdogInstanceEvent('finish'));
+						// we delete after a microtask to avoid returnModifier
+						// not founding the instance in case of a syncronous
+						// cancellation (for example with drop)
+						queueMicrotask(() => {
+							instances.delete(instance_id);
+							for (const off of instance.offs) {
+								off();
+							}
+						});
+					}
+					event_target.dispatchEvent(new SheepdogEvent('instance-cancel'));
+					event_target.dispatchEvent(new SheepdogEvent('instance-finish'));
+					if (![...instances.values()].some((instance) => instance.is_running)) {
+						event_target.dispatchEvent(new SheepdogEvent('finish'));
+					}
+				},
+				onInstanceCreate(instance_id) {
+					const instance_event_target = new EventTarget();
+					const offs = new Set<() => void>();
+					const instance: MappedInstance<TReturn> = {
+						event_target: instance_event_target,
+						offs,
+						instance: {
+							on(event, cb, options) {
+								instance_event_target.addEventListener(event, cb, options);
+								function off() {
+									instance_event_target.removeEventListener(event, cb, options);
+								}
+								offs.add(off);
+								return off;
+							},
+							error: undefined,
+							value: undefined,
+						},
+						is_running: false,
+					};
+					task_instance.last = instance.instance;
+					if (instances.size === 0) {
+						event_target.dispatchEvent(new SheepdogEvent('start'));
+					}
+					instances.set(instance_id, instance);
+					event_target.dispatchEvent(new SheepdogEvent('instance-create'));
+				},
+				onInstanceStart(instance_id) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						task_instance.lastRunning = instance.instance;
+						instance.event_target.dispatchEvent(new SheepdogInstanceEvent('start'));
+						instance.is_running = true;
+						update_is_running();
+					}
+					task_instance.performCount++;
+					event_target.dispatchEvent(new SheepdogEvent('instance-start'));
+				},
+				onInstanceComplete(instance_id, last_result) {
+					const instance = instances.get(instance_id);
+					if (instance) {
+						task_instance.lastRunning = undefined;
+						task_instance.lastSuccessful = instance.instance;
+						instance.instance.value = last_result;
+						instance.is_running = false;
+						update_is_running();
+						instance.event_target.dispatchEvent(new SheepdogInstanceEvent('success'));
+						instance.event_target.dispatchEvent(new SheepdogInstanceEvent('finish'));
+						// we delete after a microtask to avoid returnModifier
+						// not founding the instance in case of a synchronous
+						// cancellation (for example with drop)
+						queueMicrotask(() => {
+							instances.delete(instance_id);
+							for (const off of instance.offs) {
+								off();
+							}
+						});
+					}
+					event_target.dispatchEvent(new SheepdogEvent('instance-success'));
+					event_target.dispatchEvent(new SheepdogEvent('instance-finish'));
+					if (![...instances.values()].some((instance) => instance.is_running)) {
+						event_target.dispatchEvent(new SheepdogEvent('finish'));
+					}
+				},
+				returnModifier(instance_id, returned_value) {
+					const instance = instances.get(instance_id);
+					if (!instance)
+						throw new Error('Return modifier has been called before the instance was created');
+					define_properties(returned_value, instance.instance);
+					return returned_value;
+				},
+			},
+			gen_or_fun,
+			options,
+		);
+		define_properties(actual_task, task_instance);
+		return actual_task;
+	}
+
+	type HandlersShorthands = {
+		[K in HandlerType]: <TArgs = undefined, TReturn = unknown>(
+			gen_or_fun: (
+				args: TArgs,
+				utils: SheepdogUtils,
+			) => Promise<TReturn> | AsyncGenerator<unknown, TReturn, unknown>,
+			options?: Parameters<HandlersMap[K]> extends [] ? object : Parameters<HandlersMap[K]>[0],
+		) => ReturnType<typeof task<TArgs, TReturn>>;
 	};
 
-	function update_is_running() {
-		task_instance.isRunning = [...instances.values()].some((val) => val.is_running);
+	const task: typeof _task & HandlersShorthands = _task as typeof _task & HandlersShorthands;
+
+	function is_key(handler: string): handler is HandlerType {
+		return handler in handlers;
 	}
 
-	const instances = new Map<string, MappedInstance<TReturn>>();
-
-	const actual_task = createTask<TArgs, TReturn, TaskInstance<TReturn>>(
-		{
-			onDestroy(fn) {
-				task_instance.destroy = fn;
-			},
-			onError(instance_id, error) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					task_instance.lastErrored = instance.instance;
-					task_instance.lastRunning = undefined;
-					instance.instance.error = error;
-					instance.is_running = false;
-					update_is_running();
-					instance.event_target.dispatchEvent(new SheepdogInstanceEvent('error'));
-					instance.event_target.dispatchEvent(new SheepdogInstanceEvent('finish'));
-					// we delete after a microtask to avoid returnModifier
-					// not finding the instance in case of a synchronous
-					// cancellation (for example with drop)
-					queueMicrotask(() => {
-						instances.delete(instance_id);
-						for (const off of instance.offs) {
-							off();
-						}
-					});
+	for (const handler in handlers) {
+		if (is_key(handler)) {
+			task[handler] = (gen_or_fun, options) => {
+				if (!is_key(handler)) {
+					throw new Error('Impossible');
 				}
-				event_target.dispatchEvent(new SheepdogEvent('instance-error'));
-				event_target.dispatchEvent(new SheepdogEvent('instance-finish'));
-				if (![...instances.values()].some((instance) => instance.is_running)) {
-					event_target.dispatchEvent(new SheepdogEvent('finish'));
-				}
-			},
-			onInstanceCancel(instance_id) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					task_instance.lastCanceled = instance.instance;
-					task_instance.lastRunning = undefined;
-					instance.is_running = false;
-					update_is_running();
-					instance.event_target.dispatchEvent(new SheepdogInstanceEvent('cancel'));
-					instance.event_target.dispatchEvent(new SheepdogInstanceEvent('finish'));
-					// we delete after a microtask to avoid returnModifier
-					// not founding the instance in case of a syncronous
-					// cancellation (for example with drop)
-					queueMicrotask(() => {
-						instances.delete(instance_id);
-						for (const off of instance.offs) {
-							off();
-						}
-					});
-				}
-				event_target.dispatchEvent(new SheepdogEvent('instance-cancel'));
-				event_target.dispatchEvent(new SheepdogEvent('instance-finish'));
-				if (![...instances.values()].some((instance) => instance.is_running)) {
-					event_target.dispatchEvent(new SheepdogEvent('finish'));
-				}
-			},
-			onInstanceCreate(instance_id) {
-				const instance_event_target = new EventTarget();
-				const offs = new Set<() => void>();
-				const instance: MappedInstance<TReturn> = {
-					event_target: instance_event_target,
-					offs,
-					instance: {
-						on(event, cb, options) {
-							instance_event_target.addEventListener(event, cb, options);
-							function off() {
-								instance_event_target.removeEventListener(event, cb, options);
-							}
-							offs.add(off);
-							return off;
-						},
-						error: undefined,
-						value: undefined,
-					},
-					is_running: false,
-				};
-				task_instance.last = instance.instance;
-				if (instances.size === 0) {
-					event_target.dispatchEvent(new SheepdogEvent('start'));
-				}
-				instances.set(instance_id, instance);
-				event_target.dispatchEvent(new SheepdogEvent('instance-create'));
-			},
-			onInstanceStart(instance_id) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					task_instance.lastRunning = instance.instance;
-					instance.event_target.dispatchEvent(new SheepdogInstanceEvent('start'));
-					instance.is_running = true;
-					update_is_running();
-				}
-				task_instance.performCount++;
-				event_target.dispatchEvent(new SheepdogEvent('instance-start'));
-			},
-			onInstanceComplete(instance_id, last_result) {
-				const instance = instances.get(instance_id);
-				if (instance) {
-					task_instance.lastRunning = undefined;
-					task_instance.lastSuccessful = instance.instance;
-					instance.instance.value = last_result;
-					instance.is_running = false;
-					update_is_running();
-					instance.event_target.dispatchEvent(new SheepdogInstanceEvent('success'));
-					instance.event_target.dispatchEvent(new SheepdogInstanceEvent('finish'));
-					// we delete after a microtask to avoid returnModifier
-					// not founding the instance in case of a synchronous
-					// cancellation (for example with drop)
-					queueMicrotask(() => {
-						instances.delete(instance_id);
-						for (const off of instance.offs) {
-							off();
-						}
-					});
-				}
-				event_target.dispatchEvent(new SheepdogEvent('instance-success'));
-				event_target.dispatchEvent(new SheepdogEvent('instance-finish'));
-				if (![...instances.values()].some((instance) => instance.is_running)) {
-					event_target.dispatchEvent(new SheepdogEvent('finish'));
-				}
-			},
-			returnModifier(instance_id, returned_value) {
-				const instance = instances.get(instance_id);
-				if (!instance)
-					throw new Error('Return modifier has been called before the instance was created');
-				define_properties(returned_value, instance.instance);
-				return returned_value;
-			},
-		},
-		gen_or_fun,
-		options,
-	);
-	define_properties(actual_task, task_instance);
-	return actual_task;
-}
-
-type HandlersShorthands = {
-	[K in HandlerType]: <TArgs = undefined, TReturn = unknown>(
-		gen_or_fun: (
-			args: TArgs,
-			utils: SheepdogUtils,
-		) => Promise<TReturn> | AsyncGenerator<unknown, TReturn, unknown>,
-		options?: Parameters<HandlersMap[K]> extends [] ? object : Parameters<HandlersMap[K]>[0],
-	) => ReturnType<typeof task<TArgs, TReturn>>;
-};
-
-const task: typeof _task & HandlersShorthands = _task as typeof _task & HandlersShorthands;
-
-function is_key(handler: string): handler is HandlerType {
-	return handler in handlers;
-}
-
-for (const handler in handlers) {
-	if (is_key(handler)) {
-		task[handler] = (gen_or_fun, options) => {
-			if (!is_key(handler)) {
-				throw new Error('Impossible');
-			}
-			return _task(gen_or_fun, { ...(options ?? {}), kind: handler });
-		};
+				return _task(gen_or_fun, { ...(options ?? {}), kind: handler });
+			};
+		}
 	}
-}
+
+	return task;
+})();
 
 export { task };


### PR DESCRIPTION
As shared in the weekly this should allow for `esbuild` and `rolldown` to also properly treeshake away `task`