### PR TITLE
fix: use spaces in `package.json`'s

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -13,6 +13,12 @@
 			}
 		},
 		{
+			"files": "package.json",
+			"options": {
+				"useTabs": false
+			}
+		},
+		{
 			"files": "*.mdx",
 			"options": {
 				"proseWrap": "always"


### PR DESCRIPTION
This should fix the lint problem everytime we release