### PR TITLE
chore: add require label workflow

### DIFF
--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -5,8 +5,6 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:

--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -1,0 +1,19 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: |
+            documentation
+            internal
+            bug
+            enhancement


### PR DESCRIPTION
Since we need a label we might just as well enforce it so we have the feedback early instead of when we merge and `release-plan` fails.