### PR TITLE
Add vanilla as an option to the bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,8 @@ body:
       label: Package name
       description: Select the Sheepdog package
       options:
-        - svelte
         - core
+        - svelte
+        - vanilla
     validations:
       required: true


### PR DESCRIPTION
This PR allows us to select `vanilla` as a package in the bug report template