### PR TITLE
breaking: bump `@sheepdog/core` version to 1.0

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,5 @@
+# @sheepdog/core
+
+This is the agnostic package used for `@sheepdog/svelte` and `@sheepdog/vanilla`.
+
+For more information you can look at this [README](https://github.com/mainmatter/sheepdog/README.md) or visit [our docs](https://sheepdog.run)


### PR DESCRIPTION
This is mostly to bring `@sheepdog/core` to 1.0