### PR TITLE
breaking: bump `@sheepdog/vanilla` version to 1.0

### DIFF
--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -1,0 +1,5 @@
+# @sheepdog/vanilla
+
+This is the vanilla package used to provide async task management in vanilla JS projects.
+
+For more information you can look at this [README](https://github.com/mainmatter/sheepdog/README.md) or visit [our docs](https://sheepdog.run)


### PR DESCRIPTION
This is mostly to bump the version of vanilla to 1.0