### PR TITLE
fix: missing sourcemaps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "dist",
+    "src",
     "!dist/tsconfig.tsbuildinfo"
   ],
   "exports": {

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -28,6 +28,7 @@
   "types": "./dist/src/index.d.ts",
   "files": [
     "dist",
+    "src",
     "!dist/tsconfig.tsbuildinfo",
     "!dist/**/*.test.*",
     "!dist/**/*.spec.*"


### PR DESCRIPTION
So the problem here is that the generated sourcemaps link to a non existing file because we don't publish the TS files on npm...the solution would either be to ship the TS files (which is what i did in this PR) or completely disable sourcemaps...i slightly lean towards this solution because while it takes a bit more space in the developer hard-drive it could help with a better dev-x.

Closes #311